### PR TITLE
created public and private types

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,5 +2,6 @@ node_modules/
 tsdist/
 .github/
 benchmark.css
+index.html
 benchmark.js
 serve.js

--- a/clone-deep-utils.js
+++ b/clone-deep-utils.js
@@ -3,16 +3,16 @@ import cloneDeep from "./clone-deep.js";
 /**
  * Deeply clones the provided object and its prototype chain.
  * @param {any} value The object to clone.
- * @param {import("./types").CloneDeepFullyOptions|import("./types").Customizer} 
+ * @param {import("./public-types.js").CloneDeepFullyOptions|import("./public-types.js").Customizer} 
  * [options] If a function, it is used as the customizer for the clone. 
  * @param {object} [options] If an object, it is used as a configuration object.
  * See the documentation for `cloneDeep`.
  * @param {boolean} options.force If `true`, prototypes with methods will be 
  * cloned. Normally, this function stops if it reaches any prototype with 
  * methods.
- * @param {import("./types").Customizer} options.customizer See the 
+ * @param {import("./public-types.js").Customizer} options.customizer See the 
  * documentation for `cloneDeep`.
- * @param {import("./types").Log} options.log See the documentation for 
+ * @param {import("./public-types.js").Log} options.log See the documentation for 
  * `cloneDeep`.
  * @param {string} options.logMode See the documentation for `cloneDeep`.
  * @param {boolean} options.letCustomizerThrow See the documentation for 
@@ -74,8 +74,10 @@ export function cloneDeepFully(value, options) {
  * Creates a customizer which composes other customizers.
  * The customizers are executed in order. The first to return an object is used 
  * as the result. If no customizer returns an object, undefined is returned.
- * @param {Function[]} customizers An array of customizer functions.
- * @returns {Function} A new customizer which composes the provided customizers.
+ * @param {import("./public-types").Customizer[]} customizers An array of 
+ * customizer functions.
+ * @returns {import("./public-types").Customizer} A new customizer which 
+ * composes the provided customizers.
  */
 export function useCustomizers(customizers) {
     if (!Array.isArray(customizers)

--- a/clone-deep.js
+++ b/clone-deep.js
@@ -212,9 +212,9 @@ function isTypedArray(tag) {
 /**
  * Clones the provided value.
  * @param {any} _value The value to clone.
- * @param {import("./types").Customizer|undefined} customizer A customizer 
+ * @param {import("./public-types").Customizer|undefined} customizer A customizer 
  * function.
- * @param {import("./types").Log} log Receives an error object for logging.
+ * @param {import("./public-types").Log} log Receives an error object for logging.
  * @param {boolean} doThrow Whether errors in the customizer should 
  * cause the function to throw.
  * @returns {any}
@@ -222,10 +222,10 @@ function isTypedArray(tag) {
 function cloneInternalNoRecursion(_value, customizer, log, doThrow) {
 
     /**
-     * @type {import("./types").Assign<any>}
+     * @type {import("./private-types").Assign<any>}
      * Handles the assignment of the cloned value to some persistent place.
      * @param {any} cloned The cloned value.
-     * @param {Object|import("./types").assigner|Symbol|Object} 
+     * @param {Object|import("./private-types").assigner|Symbol|Object} 
      * [parentOrAssigner] Either the parent object that the cloned value will 
      * be assigned to, or a function which assigns the value itself. If equal to 
      * `TOP_LEVEL`, then it is the value that will be returned by the algorithm. 
@@ -289,7 +289,7 @@ function cloneInternalNoRecursion(_value, customizer, log, doThrow) {
 
     /** 
      * A queue so we can avoid recursion.
-     * @type {import("./types").QueueElement[]}
+     * @type {import("./private-types").QueueElement[]}
      */ 
     const queue = [{ value: _value, parentOrAssigner: TOP_LEVEL }];
     
@@ -371,7 +371,7 @@ function cloneInternalNoRecursion(_value, customizer, log, doThrow) {
             /** @type {any} */
             let clone;
 
-            /** @type {import("./types").AdditionalValues|undefined} */
+            /** @type {import("./public-types").AdditionalValues|undefined} */
             let additionalValues; 
 
             /** @typo {boolean|undefined} */
@@ -600,7 +600,7 @@ function cloneInternalNoRecursion(_value, customizer, log, doThrow) {
                 }
                 
                 else if (isTypedArray(tag)) {
-                    /** @type {import("./types").TypedArrayConstructor} */
+                    /** @type {import("./private-types").TypedArrayConstructor} */
                     const TypedArray = value.constructor;
 
                     /** @type {ArrayBufferConstructor} */
@@ -754,19 +754,18 @@ function cloneInternalNoRecursion(_value, customizer, log, doThrow) {
 
 /**
  * @param {any} value The value to deeply copy.
- * @param {import("./types").CloneDeepOptions|import("./types").Customizer} 
+ * @param {import("./public-types").CloneDeepOptions|import("./public-types").Customizer} 
  * [optionsOrCustomizer] If a function, this argument is used as the customizer.
  * @param {object} [optionsOrCustomizer] If an object, this argument is used as 
  * a configuration object.
- * @param {import("./types").Customizer} optionsOrCustomizer.customizer Allows 
- * the user to inject custom logic. The function is given the value to copy. If 
- * the function returns an object, the value of the `clone` property on that 
- * object will be used as the clone. See the documentation for `cloneDeep` for 
- * more information.
- * @param {import("./types").Log} optionsOrCustomizer.log Any errors which occur 
- * during the algorithm can optionally be passed to a log function. `log` should 
- * take one argument which will be the error encountered. Use this to the log 
- * the error to a custom logger.
+ * @param {import("./public-types").Customizer} optionsOrCustomizer.customizer 
+ * Allows the user to inject custom logic. The function is given the value to 
+ * copy. If the function returns an object, the value of the `clone` property on 
+ * that object will be used as the clone.
+ * @param {import("./public-types").Log} optionsOrCustomizer.log Any errors 
+ * which occur during the algorithm can optionally be passed to a log function. 
+ * `log` should take one argument which will be the error encountered. Use this 
+ * to log the error to a custom logger.
  * @param {string} optionsOrCustomizer.logMode Case-insensitive. If "silent", no 
  * warnings will be logged. Use with caution, as failures to perform true clones 
  * are logged as warnings. If "quiet", the stack trace of the warning is 
@@ -777,10 +776,10 @@ function cloneInternalNoRecursion(_value, customizer, log, doThrow) {
  * @returns {Object} The deep copy.
  */
 function cloneDeep(value, optionsOrCustomizer) {
-    /** @type {import("./types").Customizer|undefined} */
+    /** @type {import("./public-types").Customizer|undefined} */
     let customizer;
 
-    /** @type {import("./types").Log|undefined} */
+    /** @type {import("./public-types").Log|undefined} */
     let log;
 
     /** @type {string|undefined} */

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "1.0.10",
   "description": "A dependency-free utility for deeply cloning JavaScript objects.",
   "main": "index.js",
-  "types": "types.d.ts",
+  "types": "public-types.d.ts",
   "keywords": [
     "clone",
     "deep"

--- a/private-types.d.ts
+++ b/private-types.d.ts
@@ -1,0 +1,33 @@
+export type assigner = (
+    value: any,
+    prop: PropertyKey | undefined,
+    metadata: PropertyDescriptor | undefined
+) => void;
+
+export type Assign<T> = (
+    value: T,
+    parentOrAssigner: assigner | symbol | Object | undefined,
+    prop: PropertyKey | undefined,
+    metadata: PropertyDescriptor | undefined
+) => T
+
+export interface QueueElement {
+    value: any,
+    parentOrAssigner?: symbol|Object|assigner,
+    prop?: string | symbol,
+    metadata?: PropertyDescriptor
+}
+
+export type TypedArrayConstructor =
+    DataViewConstructor |
+    Float32ArrayConstructor |
+    Float64ArrayConstructor |
+    Int8ArrayConstructor |
+    Int16ArrayConstructor |
+    Int32ArrayConstructor |
+    Uint8ArrayConstructor |
+    Uint8ClampedArrayConstructor |
+    Uint16ArrayConstructor |
+    Uint32ArrayConstructor |
+    BigInt64ArrayConstructor |
+    BigUint64ArrayConstructor;

--- a/public-types.d.ts
+++ b/public-types.d.ts
@@ -1,5 +1,3 @@
-// Public Types ==============
-
 export interface AdditionalValues {
     value: any,
     assigner: (clone: any) => void
@@ -27,43 +25,6 @@ export interface CloneDeepOptions {
 export interface CloneDeepFullyOptions extends CloneDeepOptions {
     force?: boolean
 }
-
-
-// Private Types ==============
-
-type assigner = (
-    value: any,
-    prop: PropertyKey | undefined,
-    metadata: PropertyDescriptor | undefined
-) => void;
-
-type Assign<T> = (
-    value: T,
-    parentOrAssigner: assigner | symbol | Object | undefined,
-    prop: PropertyKey | undefined,
-    metadata: PropertyDescriptor | undefined
-) => T
-
-interface QueueElement {
-    value: any,
-    parentOrAssigner?: Symbol|Object|assigner,
-    prop?: string | symbol,
-    metadata?: PropertyDescriptor
-}
-
-type TypedArrayConstructor =
-    DataViewConstructor |
-    Float32ArrayConstructor |
-    Float64ArrayConstructor |
-    Int8ArrayConstructor |
-    Int16ArrayConstructor |
-    Int32ArrayConstructor |
-    Uint8ArrayConstructor |
-    Uint8ClampedArrayConstructor |
-    Uint16ArrayConstructor |
-    Uint32ArrayConstructor |
-    BigInt64ArrayConstructor |
-    BigUint64ArrayConstructor;
 
 
 declare module "cms-clone-deep" {


### PR DESCRIPTION
Created public and private types files. This should stop TypeScript from allowing the user to import unnecessary types.

I also included index.html in npmignore.