### PR TITLE
Error subclasses

### DIFF
--- a/clone-deep-helpers.js
+++ b/clone-deep-helpers.js
@@ -157,9 +157,6 @@ const prototypes = [
  * }
  * ```
  * 
- * This second approach to type-checking is referred to as "experimental 
- * type-checking".
- * 
  * @param {any} value 
  * The value to get the tag of.
  * @returns {string} tag 
@@ -227,11 +224,14 @@ const prototypeMap = Object.freeze({
  * @param {any} [value]
  * The object itself. This is necessary to correctly find constructors for 
  * various Error subclasses.
+ * @param {(error: Error) => any} [log]
+ * An optional logging function.
  * @returns {any}
  */
-export function getConstructor(tag, value) {
+export function getConstructor(tag, value, log) {
     if (tag === Tag.ERROR) {
         const name = Object.getPrototypeOf(value).name;
+        console.log(name);
         switch (name) {
             case "AggregateError":
                 return AggregateError;
@@ -248,8 +248,10 @@ export function getConstructor(tag, value) {
             case "URIError":
                 return URIError;
             default:
-                getWarning(`Cloning error with unrecognized name ${name}!` + 
-                           "It will be cloned into an ordinary Error object.")
+                if (log !== undefined)
+                    log(getWarning("Cloning error with unrecognized name " + 
+                                   `${name}! It will be cloned into an ` + 
+                                   "ordinary Error object."))
                 return Error;
         }
     }

--- a/clone-deep-helpers.js
+++ b/clone-deep-helpers.js
@@ -216,16 +216,43 @@ const prototypeMap = Object.freeze({
 });
 
 /**
- * Gets the appropriate supported constructor for the given object.
+ * Gets the appropriate supported constructor for the given object tag.
  * 
  * **This function assumes the provided object is one of the supported 
  * classes.**
  * 
  * I could not find a way to type this without using `any`. Forgive me. 
  * @param {string} tag
+ * The tag for the object.
+ * @param {any} [value]
+ * The object itself. This is necessary to correctly find constructors for 
+ * various Error subclasses.
  * @returns {any}
  */
-export function getConstructor(tag) {
+export function getConstructor(tag, value) {
+    if (tag === Tag.ERROR) {
+        const name = Object.getPrototypeOf(value).name;
+        switch (name) {
+            case "AggregateError":
+                return AggregateError;
+            case "EvalError":
+                return EvalError;
+            case "RangeError":
+                return RangeError;
+            case "ReferenceError":
+                return ReferenceError;
+            case "SyntaxError":
+                return SyntaxError;
+            case "TypeError":
+                return TypeError;
+            case "URIError":
+                return URIError;
+            default:
+                getWarning(`Cloning error with unrecognized name ${name}!` + 
+                           "It will be cloned into an ordinary Error object.")
+                return Error;
+        }
+    }
     return prototypeMap[tag];
 }
 

--- a/clone-deep.js
+++ b/clone-deep.js
@@ -365,7 +365,7 @@ function cloneInternalNoRecursion(_value,
                 const error = value;
 
                 /** @type {ErrorConstructor} */
-                const ErrorConstructor = value.constructor;
+                const ErrorConstructor = getConstructor(tag, error);
 
                 const cause = error.cause;
                 const clonedError = cause === undefined

--- a/clone-deep.js
+++ b/clone-deep.js
@@ -365,7 +365,7 @@ function cloneInternalNoRecursion(_value,
                 const error = value;
 
                 /** @type {ErrorConstructor} */
-                const ErrorConstructor = getConstructor(tag, error);
+                const ErrorConstructor = getConstructor(tag, error, log);
 
                 const cause = error.cause;
                 const clonedError = cause === undefined

--- a/test.js
+++ b/test.js
@@ -502,6 +502,24 @@ try {
             assert.strictEqual(cloned.property, error.property);
         });
 
+        test("Error subclasses are correctly cloned", () => {
+            [
+                AggregateError, 
+                EvalError,
+                RangeError, 
+                ReferenceError, 
+                SyntaxError, 
+                TypeError, 
+                URIError
+            ].forEach(ErrorClass => {
+                const error = new ErrorClass("error");
+
+                const cloned = cloneDeep(error);
+
+                assert.strictEqual(getProto(cloned), ErrorClass.prototype);
+            });
+        });
+
         test('Function.prototype is "cloned" with allowed properties', () => {
             const expectedProperties = [
                 "length",

--- a/test.js
+++ b/test.js
@@ -520,6 +520,46 @@ try {
             });
         });
 
+        test("Unrecognized error cloned w/ Error constructor + warning", () => {
+            const ErrorOriginal = Error;
+
+            try {
+                // -- arrange
+                class TestError extends Error {};
+                Object.defineProperty(TestError.prototype, "name", {
+                    value: "TestError"
+                });
+
+                const log = mock.fn(() => {});
+                
+                // monkeypatch Error so we can track if it was called
+                let errorOriginalCount = 0;
+                Error = function(...args) {
+                    errorOriginalCount++;
+                    return ErrorOriginal(...args);
+                }
+                Error.prototype = ErrorOriginal.prototype;
+                
+                // -- act
+                cloneDeep(new ArbitraryError("error"), { log: undefined });
+                cloneDeep(new ArbitraryError("error"), { log });
+                
+                // -- assert
+                assert.strictEqual(2, errorOriginalCount);
+                assert.strictEqual(true, 
+                                   log
+                                    .mock
+                                    .calls[0]
+                                    .arguments[0]
+                                    .message
+                                    .includes("Cloning error with " + 
+                                              "unrecognized name TestError!"));
+            }
+            catch(_error) {
+                Error = ErrorOriginal;
+            }
+        });
+
         test('Function.prototype is "cloned" with allowed properties', () => {
             const expectedProperties = [
                 "length",


### PR DESCRIPTION
AggregateError, TypeError, etc are cloned into themselves instead of Error now.