### PR TITLE
Tests reformatted

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,19 +194,19 @@ JavaScript has a native function `structuredClone` which deeply clones objects. 
 
 There are some features which are only accessible by cloning the repository. This is done by installing [git](https://git-scm.com/downloads). Once you have `git`, execute `git clone https://github.com/calebmsword/clone-deep.git` and a directory *clone-deep/* will be made containing the source code. Then execute `npm install`.
 
-### TypeScript & JSDoc
+## TypeScript & JSDoc
 
 This repository uses type annotations in [JSDoc](https://jsdoc.app/) to add type-checking to JavaScript. While this requires the `typescript` module, there is no compilation step. The codebase is entirely JavaScript, but VSCode will still highlight errors like it would for TypeScript files. If you are using an IDE which cannot conveniently highlight TypeScript errors, then you can use the TypeScript compiler to check typing (`npm i -g typescript`, then run `npx tsc` in the repository).
 
-### testing
+## testing
 
-The file `clone-deep.test.js` contains all unit tests. Execute `node --test` to run them. If you are using node v20.1.0 or higher, execute `node --test --experimental-test-coverage` to see coverage results.
+The file `clone-deep.test.js` contains all unit tests. Execute `npm test` to run them. If you are using node v20.1.0 or higher, execute `node run test-coverage` to see coverage results.
 
-### benchmarking
+## benchmarking
 
 Some rudimentary benchmarking can be done within the repository. In the directory containing the source code, execute `node serve.js <PORT>`, where the `PORT` command line option is optional and defaults to `8787`, and visit `http://localhost:<PORT>` to see the benchmarking UI. `benchmark.js` and `benchmark.css` contain the JavaScript and styling, respectively, for the hosted web page. You can use your favorite browser's dev tools to profile the result.
 
-### contribution guidelines
+## contribution guidelines
 
   - If you notice a bug or have a feature request, please raise an issue. Follow the default template provided for bug reports or feature requests, respectively.
   - If you would like to implement a bug fix or feature request from an issue, please create a branch from the `dev` branch with a descriptive name relevant to the issue title. Once you are finished with the implementation, create a pull request to the `dev` branch.

--- a/clone-deep-helpers.js
+++ b/clone-deep-helpers.js
@@ -231,7 +231,6 @@ const prototypeMap = Object.freeze({
 export function getConstructor(tag, value, log) {
     if (tag === Tag.ERROR) {
         const name = Object.getPrototypeOf(value).name;
-        console.log(name);
         switch (name) {
             case "AggregateError":
                 return AggregateError;

--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
     "clone",
     "deep"
   ],
+  "scripts": {
+    "test": "node --test",
+    "test-coverage": "node --test --experimental-test-coverage"
+  },
   "author": "Caleb Sword",
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
Tests obey the 80-character restriction and I fixed a mistake in the test for Error subclasses. Test scripts have been added to package.json and the README has been updated to match.