### PR TITLE
Native class tag acquisition updated 

### DIFF
--- a/clone-deep-helpers.js
+++ b/clone-deep-helpers.js
@@ -104,12 +104,20 @@ export const forbiddenProps = Object.freeze({
  * @type {Array<[any, string, string]>} 
  */
 const prototypes = [
+    [ArrayBuffer, "slice", Tag.ARRAYBUFFER],
+    [BigInt, "valueOf", Tag.BIGINT],
+    [Boolean, "valueOf", Tag.BOOLEAN],
     [Date, "getUTCMilliseconds", Tag.DATE],
     [Function, "bind", Tag.FUNCTION],
     [Map, "has", Tag.MAP],
+    [Number, "valueOf", Tag.NUMBER],
+    [Promise, "then", Tag.PROMISE],
     [RegExp, "exec", Tag.REGEXP],
-    [Set, "has", Tag.SET]
-]
+    [Set, "has", Tag.SET],
+    [String, "valueOf", Tag.STRING],
+    [Symbol, "valueOf", Tag.SYMBOL],
+    [DataView, "getInt8", Tag.DATAVIEW]
+];
 
 /**
  * Gets a "tag", which is an string which identifies the type of a value.
@@ -136,7 +144,7 @@ const prototypes = [
  * 
  * // Note this is not a perfect type check because we can do:
  * arraySubclass[Symbol.toStringTag] = "Array"
- * console.log(Object.prototype.toString.call(dateSubClass));  // "[object Array]"
+ * console.log(Object.prototype.toString.call(arraySubclass));  // "[object Array]"
  * ```
  * 
  * However, some native classes will throw if their prototype methods are called 

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
                 <div class="label">Number of iterations:</div>
             </div>
             <div class="input-container">
-                <input class="iterations" type="number" placeholder="100">
+                <input class="iterations" type="number" placeholder="1000">
             </div>
         </div>
         <div class="buttons">

--- a/test.js
+++ b/test.js
@@ -173,6 +173,7 @@ try {
                 const cloned = cloneDeep(value);
 
                 // -- assert
+                assert.strictEqual(typeof cloned, "object");
                 assert.strictEqual(tagOf(cloned), tag);
             }
         });


### PR DESCRIPTION
The new approach to getting tags has been implemented for 

- ArrayBuffer
- BigInt
- Boolean
- Number
- promsie
- String
- Symbol
- DataView

A test that checks that Native classes are cloned properly has been updated (cloning a String/Symbol/BigInt/etc into a primitive would have passed the old version of the test).