### PR TITLE
Objects define their clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,10 +163,8 @@ The object returned by the clone method can have up to three properties.
 
  - `clone` - Whatever is assigned here will be used as the clone for the given object. If this property is not present or returns undefined, then the cloning method will be ignored and the algorithm will proceed with default behavior.
  - `propsToIgnore` - This should be an array where each element is a string or symbol. Normally, the algorithm will observe each property in an object to ensure that it is cloned. However, if an instance of a class with aclone method provides any properties in the `propsToIgnore` array, they will be cloned by the algorithm, giving you the opportunity to clone some properties with a cloning method instead.
-  - `ignoreProps` - This should be a boolean. If this is a boolean and is true, then the cloning method will have the full responsibility of cloning all properties on the instance. 
-  - `ignoreProto` - This should be a boolean. If this is a boolean and is true, 
-  then the cloning method will have the full responsibility of determining the 
-  prototype of the cloned value.
+ - `ignoreProps` - This should be a boolean. If this is a boolean and is true, then the cloning method will have the full responsibility of cloning all properties on the instance. 
+ - `ignoreProto` - This should be a boolean. If this is a boolean and is true, then the cloning method will have the full responsibility of determining the prototype of the cloned value.
 
 ## customizers
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ cloned = cloneDeep(originalObject, {
 
 `cloneDeep` has none of these limitations. See [this section](#cloneDeep-vs-structuredClone) for more about the differences between `cloneDeep` and `structuredClone`.
 
-## What cannot be cloned
+## what cannot be cloned
 
 Functions cannot be reliably cloned in JavaScript. 
  - It is impossible to clone native JavaScript functions.
@@ -164,6 +164,9 @@ The object returned by the clone method can have up to three properties.
  - `clone` - Whatever is assigned here will be used as the clone for the given object. If this property is not present or returns undefined, then the cloning method will be ignored and the algorithm will proceed with default behavior.
  - `propsToIgnore` - This should be an array where each element is a string or symbol. Normally, the algorithm will observe each property in an object to ensure that it is cloned. However, if an instance of a class with aclone method provides any properties in the `propsToIgnore` array, they will be cloned by the algorithm, giving you the opportunity to clone some properties with a cloning method instead.
   - `ignoreProps` - This should be a boolean. If this is a boolean and is true, then the cloning method will have the full responsibility of cloning all properties on the instance. 
+  - `ignoreProto` - This should be a boolean. If this is a boolean and is true, 
+  then the cloning method will have the full responsibility of determining the 
+  prototype of the cloned value.
 
 ## customizers
 
@@ -292,7 +295,7 @@ This repository uses type annotations in [JSDoc](https://jsdoc.app/) to add type
 
 ## testing
 
-The file `clone-deep.test.js` contains all unit tests. Execute `npm test` to run them. If you are using node v20.1.0 or higher, execute `node run test-coverage` to see coverage results.
+The file `clone-deep.test.js` contains all unit tests. Execute `npm test` to run them. If you are using node v20.1.0 or higher, execute `npm run test-coverage` to see coverage results.
 
 ## benchmarking
 

--- a/clone-deep-helpers.js
+++ b/clone-deep-helpers.js
@@ -336,3 +336,6 @@ export function isTypedArray(tag) {
         Tag.BIGUINT64
     ].includes(tag);
 }
+
+/** Used to create methods for cloning objects.*/
+export const CLONE = Symbol("Clone");

--- a/clone-deep-helpers.js
+++ b/clone-deep-helpers.js
@@ -104,12 +104,20 @@ export const forbiddenProps = Object.freeze({
  * @type {Array<[any, string, string]>} 
  */
 const prototypes = [
+    [ArrayBuffer, "slice", Tag.ARRAYBUFFER],
+    [BigInt, "valueOf", Tag.BIGINT],
+    [Boolean, "valueOf", Tag.BOOLEAN],
     [Date, "getUTCMilliseconds", Tag.DATE],
     [Function, "bind", Tag.FUNCTION],
     [Map, "has", Tag.MAP],
+    [Number, "valueOf", Tag.NUMBER],
+    [Promise, "then", Tag.PROMISE],
     [RegExp, "exec", Tag.REGEXP],
-    [Set, "has", Tag.SET]
-]
+    [Set, "has", Tag.SET],
+    [String, "valueOf", Tag.STRING],
+    [Symbol, "valueOf", Tag.SYMBOL],
+    [DataView, "getInt8", Tag.DATAVIEW]
+];
 
 /**
  * Gets a "tag", which is an string which identifies the type of a value.
@@ -136,7 +144,7 @@ const prototypes = [
  * 
  * // Note this is not a perfect type check because we can do:
  * arraySubclass[Symbol.toStringTag] = "Array"
- * console.log(Object.prototype.toString.call(dateSubClass));  // "[object Array]"
+ * console.log(Object.prototype.toString.call(arraySubclass));  // "[object Array]"
  * ```
  * 
  * However, some native classes will throw if their prototype methods are called 

--- a/clone-deep-helpers.js
+++ b/clone-deep-helpers.js
@@ -196,9 +196,11 @@ export function getTag(value) {
  * Gets the appropriate TypedArray constructor for the given object tag.
  * @param {string} tag
  * The tag for the object.
+ * @param {import("./public-types").Log} log
+ * A logging function.
  * @returns {import("./private-types").TypedArrayConstructor}
  */
-export function getTypedArrayConstructor(tag) {
+export function getTypedArrayConstructor(tag, log) {
     switch (tag) {
         case Tag.DATAVIEW:
             return DataView;
@@ -224,12 +226,9 @@ export function getTypedArrayConstructor(tag) {
             return BigInt64Array;
         case Tag.BIGUINT64:
             return BigUint64Array;
-
-        // TypeScript notices that this function would return `undefined` if 
-        // none of the previous cases are hit. However, this function is only 
-        // called if `isTypedArray` is true, so this default case will never 
-        // happen in practice. We include it only to keep TypeScript happy.
         default:
+            log(getWarning("Unrecognized TypedArray subclass. This object " + 
+                           "will be cloned into a DataView instance."));
             return DataView;
     }
 }
@@ -331,26 +330,24 @@ export const Warning = {
         "value as the original Promise.")
 }
 
+const TypedArrayProto = Object
+    .getPrototypeOf(Object
+        .getPrototypeOf(new Float32Array(new ArrayBuffer(0))));
+
 /**
- * Returns `true` if tag is that of a TypedArray subclass, `false` otherwise.
- * @param {string} tag A tag. See {@link tagOf}.
+ * Returns `true` if given value is a TypedArray instance, `false` otherwise.
+ * @param {string} value 
+ * Any arbitrary value
  * @returns {boolean}
  */
-export function isTypedArray(tag) {
-    return [   
-        Tag.DATAVIEW, 
-        Tag.FLOAT32,
-        Tag.FLOAT64,
-        Tag.INT8,
-        Tag.INT16,
-        Tag.INT32,
-        Tag.UINT8,
-        Tag.UINT8CLAMPED,
-        Tag.UINT16,
-        Tag.UINT32,
-        Tag.BIGINT64,
-        Tag.BIGUINT64
-    ].includes(tag);
+export function isTypedArray(value) {
+    try {
+        TypedArrayProto.lastIndexOf.call(value);
+        return true;
+    }
+    catch(_) {
+        return false;
+    }
 }
 
 /** Used to create methods for cloning objects.*/

--- a/clone-deep-utils.js
+++ b/clone-deep-utils.js
@@ -12,11 +12,11 @@ import cloneDeep from "./clone-deep.js";
  * stops if it reaches any prototype with methods.
  * @param {import("./public-types.js").Customizer} options.customizer 
  * See the documentation for `cloneDeep`.
+ * @param {boolean} options.ignoreCloningMethods
+ * See the documentation for `cloneDeep`.
  * @param {import("./public-types.js").Log} options.log 
  * See the documentation for `cloneDeep`.
  * @param {string} options.logMode 
- * See the documentation for `cloneDeep`.
- * @param {boolean} options.useExperimentalTypeChecking
  * See the documentation for `cloneDeep`.
  * @param {boolean} options.letCustomizerThrow 
  * See the documentation for `cloneDeep`.

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
                 <div class="label">Number of iterations:</div>
             </div>
             <div class="input-container">
-                <input class="iterations" type="number" placeholder="100">
+                <input class="iterations" type="number" placeholder="1000">
             </div>
         </div>
         <div class="buttons">

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
 import cloneDeep from "./clone-deep.js";
 export { cloneDeepFully, useCustomizers } from "./clone-deep-utils.js";
+export { CLONE } from "./clone-deep-helpers.js";
 export default cloneDeep;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "cms-clone-deep",
   "repository": "https://github.com/calebmsword/clone-deep",
   "type": "module",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "A dependency-free utility for deeply cloning JavaScript objects.",
   "main": "index.js",
   "types": "public-types.d.ts",

--- a/public-types.d.ts
+++ b/public-types.d.ts
@@ -8,7 +8,7 @@ export interface ValueTransform {
     additionalValues?: AdditionalValue[],
     ignore?: boolean,
     ignoreProps?: boolean,
-    ignoreProto?: boolean
+    ignoreProto?: boolean,
 }
 
 export type Customizer = (value: any) => ValueTransform|void;

--- a/public-types.d.ts
+++ b/public-types.d.ts
@@ -30,7 +30,8 @@ export interface CloneDeepFullyOptions extends CloneDeepOptions {
 export interface CloneMethodResult<T> {
     clone: T
     propsToIgnore?: (string|symbol)[]
-    ignoreProps?: boolean
+    ignoreProps?: boolean,
+    ignoreProto: true
 }
 
 declare module "cms-clone-deep" {

--- a/public-types.d.ts
+++ b/public-types.d.ts
@@ -18,6 +18,7 @@ export type Log = (error: Error) => any;
 export interface CloneDeepOptions {
     customizer?: Customizer
     log?: Log,
+    ignoreCloningMethods?: boolean
     logMode?: string
     letCustomizerThrow?: boolean
 }
@@ -26,6 +27,11 @@ export interface CloneDeepFullyOptions extends CloneDeepOptions {
     force?: boolean
 }
 
+export interface CloneMethodResult<T> {
+    clone: T
+    propsToIgnore?: (string|symbol)[]
+    ignoreProps?: boolean
+}
 
 declare module "cms-clone-deep" {
 
@@ -178,8 +184,7 @@ declare module "cms-clone-deep" {
  * @param {Customizer} optionsOrCustomizer.customizer 
  * Allows the user to inject custom logic. The function is given the value to 
  * copy. If the function returns an object, the value of the `clone` property on 
- * that object will be used as the clone. See the documentation for `cloneDeep` 
- * for more information.
+ * that object will be used as the clone.
  * @param {Log} optionsOrCustomizer.log 
  * Any errors which occur during the algorithm can optionally be passed to a log 
  * function. `log` should take one argument which will be the error encountered. 
@@ -188,10 +193,13 @@ declare module "cms-clone-deep" {
  * Case-insensitive. If "silent", no warnings will be logged. Use with caution, 
  * as failures to perform true clones are logged as warnings. If "quiet", the 
  * stack trace of the warning is ignored.
+ * @param {boolean} optionsOrCustomizer.ignoreCloningMethods 
+ * If true, cloning methods asociated with an object will not be used to clone 
+ * the object.
  * @param {boolean} optionsOrCustomizer.letCustomizerThrow 
- * If `true`, errors 
- * thrown by the customizer will be thrown by `cloneDeep`. By default, the error 
- * is logged and the algorithm proceeds with default behavior.
+ * If `true`, errors thrown by the customizer will be thrown by `cloneDeep`. By 
+ * default, the error is logged and the algorithm proceeds with default 
+ * behavior.
  * @returns {Object} 
  * The deep copy.
  */
@@ -200,7 +208,7 @@ export default function cloneDeep(
     optionsOrCustomizer: CloneDeepOptions|Customizer|undefined
 ) : any;
     
-    /**
+/**
  * Deeply clones the provided object and its prototype chain.
  * @param {any} value 
  * The object to clone.
@@ -217,6 +225,8 @@ export default function cloneDeep(
  * @param {Log} options.log 
  * See the documentation for `cloneDeep`.
  * @param {string} options.logMode 
+ * See the documentation for `cloneDeep`.
+ * @param {boolean} optionsOrCustomizer.ignoreCloningMethods 
  * See the documentation for `cloneDeep`.
  * @param {boolean} options.letCustomizerThrow 
  * See the documentation for `cloneDeep`.

--- a/public-types.d.ts
+++ b/public-types.d.ts
@@ -173,9 +173,8 @@ declare module "cms-clone-deep" {
  * the check for circular references. 
  * 
  * The best use of the customizer to support user-made types. You can also use 
- * it to override some of the design decisions made in the algorithm (you could, 
- * for example, use it to throw if the user tries to clone functions, 
- * `WeakMaps`, or `WeakSets`).
+ * it to override some of the design decisions made in the algorithm (say, 
+ * ignore all non-enumerable properties of an object).
  * 
  * @template T
  * The type of the input value.

--- a/public-types.d.ts
+++ b/public-types.d.ts
@@ -205,17 +205,10 @@ declare module "cms-clone-deep" {
  * If true, cloning methods asociated with an object will not be used to clone 
  * the object.
  * @param {boolean} optionsOrCustomizer.letCustomizerThrow 
-<<<<<<< HEAD
  * If `true`, errors thrown by the customizer will be thrown by `cloneDeep`. By 
  * default, the error is logged and the algorithm proceeds with default 
  * behavior.
- * @returns {Object} 
-=======
- * If `true`, errors 
- * thrown by the customizer will be thrown by `cloneDeep`. By default, the error 
- * is logged and the algorithm proceeds with default behavior.
  * @returns {U} 
->>>>>>> dev
  * The deep copy.
  */
 export default function cloneDeep<T, U = T>(

--- a/test.js
+++ b/test.js
@@ -4,7 +4,8 @@ import { describe, mock, test } from "node:test";
 import { 
     Tag, 
     supportedPrototypes, 
-    forbiddenProps 
+    forbiddenProps, 
+    CLONE
 } from "./clone-deep-helpers.js";
 import  cloneDeep from "./clone-deep.js";
 import { cloneDeepFully, useCustomizers } from "./clone-deep-utils.js";
@@ -1273,6 +1274,23 @@ try {
         });
     });
 
+    describe("CLONE", () => {
+        test("CLONE can customize the clone", () => {
+            // -- arrange
+
+            // -- act
+
+            // -- assert
+        });
+
+        test("CLONE can ", () => {
+            // -- arrange
+
+            // -- act
+
+            // -- assert
+        });
+    });
 
 }
 catch(error) {

--- a/test.js
+++ b/test.js
@@ -1275,7 +1275,8 @@ try {
     });
 
     describe("CLONE", () => {
-        test("CLONE can customize the clone", () => {
+        test("classes can use the CLONE symbol to create a method " + 
+             "responsible for defining the clone of their instances", () => {
             // -- arrange
 
             // -- act
@@ -1283,7 +1284,35 @@ try {
             // -- assert
         });
 
-        test("CLONE can ", () => {
+        test("cloning methods can be ignored entirely if the correct option " + 
+             "is used", () => {
+            // -- arrange
+
+            // -- act
+
+            // -- assert
+        });
+
+        test("cloning methods can be ignored entirely if the correct option " + 
+             "is used", () => {
+            // -- arrange
+
+            // -- act
+
+            // -- assert
+        });
+        
+        test("cloning methods can cause the algorithm to not recurse on " + 
+             "specific properties on the clone", () => {
+            // -- arrange
+
+            // -- act
+
+            // -- assert
+        });
+
+        test("cloning methods can be fully responsible for cloning all " + 
+             "properties of the resultant clone", () => {
             // -- arrange
 
             // -- act

--- a/test.js
+++ b/test.js
@@ -173,6 +173,7 @@ try {
                 const cloned = cloneDeep(value);
 
                 // -- assert
+                assert.strictEqual(typeof cloned, "object");
                 assert.strictEqual(tagOf(cloned), tag);
             }
         });

--- a/test.js
+++ b/test.js
@@ -1560,10 +1560,10 @@ try {
                                           "strings or symbols"));
         });
 
-        test("if using cloneDeepFully and observing cloning methods, then " + 
-             "any prototype containing a cloning method used for an instance " + 
-             "cloned previously in the chain will not be cloned using its " + 
-             "cloning method", () => {
+        test("if using cloneDeepFully in force mode and observing cloning " + 
+             "methods, then any prototype containing a cloning method used " + 
+             "for an instance cloned previously in the chain will not be " + 
+             "cloned using its cloning method", () => {
             // -- arrange
             class Test {
                 [CLONE]() {
@@ -1592,9 +1592,9 @@ try {
             assert.strictEqual(getProto(cloned2).test, undefined);
         });
 
-        test("If using cloneDeepFully and observing cloning methods, objects " + 
-             "NOT instantiated as a class will have their prototype use its " + 
-             "cloning method", () => {
+        test("If using cloneDeepFully in force mode and observing cloning " + 
+             "methods, objects NOT instantiated as a class will have their " + 
+             "prototype use its cloning method", () => {
             // -- arrange
             const c = {
                 [CLONE]() {


### PR DESCRIPTION
- Classes have the responsibility of determining how their instances are cloned.
- README is updated to account for this feature.
- isTypedArray helper improved. unrecognized TypedArray instances are cloned into DataView instances now.