### PR TITLE
1.0.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,10 +163,8 @@ The object returned by the clone method can have up to three properties.
 
  - `clone` - Whatever is assigned here will be used as the clone for the given object. If this property is not present or returns undefined, then the cloning method will be ignored and the algorithm will proceed with default behavior.
  - `propsToIgnore` - This should be an array where each element is a string or symbol. Normally, the algorithm will observe each property in an object to ensure that it is cloned. However, if an instance of a class with aclone method provides any properties in the `propsToIgnore` array, they will be cloned by the algorithm, giving you the opportunity to clone some properties with a cloning method instead.
-  - `ignoreProps` - This should be a boolean. If this is a boolean and is true, then the cloning method will have the full responsibility of cloning all properties on the instance. 
-  - `ignoreProto` - This should be a boolean. If this is a boolean and is true, 
-  then the cloning method will have the full responsibility of determining the 
-  prototype of the cloned value.
+ - `ignoreProps` - This should be a boolean. If this is a boolean and is true, then the cloning method will have the full responsibility of cloning all properties on the instance. 
+ - `ignoreProto` - This should be a boolean. If this is a boolean and is true, then the cloning method will have the full responsibility of determining the prototype of the cloned value.
 
 ## customizers
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ cloned = cloneDeep(originalObject, {
 
 `cloneDeep` has none of these limitations. See [this section](#cloneDeep-vs-structuredClone) for more about the differences between `cloneDeep` and `structuredClone`.
 
-## What cannot be cloned
+## what cannot be cloned
 
 Functions cannot be reliably cloned in JavaScript. 
  - It is impossible to clone native JavaScript functions.
@@ -164,6 +164,9 @@ The object returned by the clone method can have up to three properties.
  - `clone` - Whatever is assigned here will be used as the clone for the given object. If this property is not present or returns undefined, then the cloning method will be ignored and the algorithm will proceed with default behavior.
  - `propsToIgnore` - This should be an array where each element is a string or symbol. Normally, the algorithm will observe each property in an object to ensure that it is cloned. However, if an instance of a class with aclone method provides any properties in the `propsToIgnore` array, they will be cloned by the algorithm, giving you the opportunity to clone some properties with a cloning method instead.
   - `ignoreProps` - This should be a boolean. If this is a boolean and is true, then the cloning method will have the full responsibility of cloning all properties on the instance. 
+  - `ignoreProto` - This should be a boolean. If this is a boolean and is true, 
+  then the cloning method will have the full responsibility of determining the 
+  prototype of the cloned value.
 
 ## customizers
 
@@ -292,7 +295,7 @@ This repository uses type annotations in [JSDoc](https://jsdoc.app/) to add type
 
 ## testing
 
-The file `clone-deep.test.js` contains all unit tests. Execute `npm test` to run them. If you are using node v20.1.0 or higher, execute `node run test-coverage` to see coverage results.
+The file `clone-deep.test.js` contains all unit tests. Execute `npm test` to run them. If you are using node v20.1.0 or higher, execute `npm run test-coverage` to see coverage results.
 
 ## benchmarking
 

--- a/clone-deep-helpers.js
+++ b/clone-deep-helpers.js
@@ -336,3 +336,6 @@ export function isTypedArray(tag) {
         Tag.BIGUINT64
     ].includes(tag);
 }
+
+/** Used to create methods for cloning objects.*/
+export const CLONE = Symbol("Clone");

--- a/clone-deep-helpers.js
+++ b/clone-deep-helpers.js
@@ -146,7 +146,7 @@ const prototypes = [
  * 
  * @example
  * ```
- * function isMap(value) {
+ * Map.isMap = value => { 
  *     try {
  *         Map.prototype.has.call(value);
  *         return true;
@@ -155,6 +155,10 @@ const prototypes = [
  *         return false;
  *     }
  * }
+ * 
+ * console.log(Map.isMap(new Map()));   // true
+ * console.log(Map.isMap(Object.create(Map.prototype)));  // false
+ * console.log(Map.isMap({ [Symbol.toStringTag]: "Map" }));  // false
  * ```
  * 
  * @param {any} value 
@@ -216,7 +220,7 @@ export function getTypedArrayConstructor(tag) {
         // TypeScript notices that this function would return `undefined` if 
         // none of the previous cases are hit. However, this function is only 
         // called if `isTypedArray` is true, so this default case will never 
-        // happen in practice. This is just to keep TypeSceript happy.
+        // happen in practice. We include it only to keep TypeScript happy.
         default:
             return DataView;
     }
@@ -230,16 +234,13 @@ export function getTypedArrayConstructor(tag) {
  * @returns {boolean}
  */
 export function isIterable(value) {
-    if (typeof value === "string") return true;
-    if (value === null || typeof value !== "object" ) return false;
+    if (value === null || value === undefined ) return false;
     return typeof value[Symbol.iterator] === "function";
 }
 
 /**
  * Gets the appropriate error constructor for the error name.
- * 
- * I could not find a way to type this without using `any`. Forgive me. 
- * @param {any} [value]
+ * @param {Error} value
  * The object itself. This is necessary to correctly find constructors for 
  * various Error subclasses.
  * @param {(error: Error) => any} [log]
@@ -247,7 +248,7 @@ export function isIterable(value) {
  * @returns {import("./private-types.js").AtomicErrorConstructor}
  */
 export function getAtomicErrorConstructor(value, log) {
-    const name = Object.getPrototypeOf(value).name;
+    const name = value.name;
     switch (name) {
         case "Error":
             return Error;

--- a/clone-deep-helpers.js
+++ b/clone-deep-helpers.js
@@ -181,80 +181,95 @@ export function getTag(value) {
 }
 
 /**
- * Convenience object used for getConstructor.
- */
-const prototypeMap = Object.freeze({
-    [Tag.ARRAY]: Array,
-    [Tag.BIGINT]: BigInt,
-    [Tag.BOOLEAN]: Boolean,
-    [Tag.DATE]: Date,
-    [Tag.ERROR]: Error,
-    [Tag.FUNCTION]: Function,
-    [Tag.MAP]: Map,
-    [Tag.NUMBER]: Number,
-    [Tag.PROMISE]: Promise,
-    [Tag.REGEXP]: RegExp,
-    [Tag.SET]: Set,
-    [Tag.STRING]: String,
-    [Tag.SYMBOL]: Symbol,
-    [Tag.ARRAYBUFFER]: ArrayBuffer,
-    [Tag.DATAVIEW]: DataView,
-    [Tag.FLOAT32]: Float32Array,
-    [Tag.FLOAT64]: Float64Array,
-    [Tag.INT8]: Int8Array,
-    [Tag.INT16]: Int16Array,
-    [Tag.INT32]: Int32Array,
-    [Tag.UINT8]: Uint8Array,
-    [Tag.UINT8CLAMPED]: Uint8ClampedArray,
-    [Tag.UINT16]: Uint16Array,
-    [Tag.UINT32]: Uint32Array,
-    [Tag.BIGINT64]: BigInt64Array,
-    [Tag.BIGUINT64]: BigUint64Array
-});
-
-/**
- * Gets the appropriate supported constructor for the given object tag.
- * 
- * **This function assumes the provided object is one of the supported 
- * classes.**
- * 
- * I could not find a way to type this without using `any`. Forgive me. 
+ * Gets the appropriate TypedArray constructor for the given object tag.
  * @param {string} tag
  * The tag for the object.
+ * @returns {import("./private-types").TypedArrayConstructor}
+ */
+export function getTypedArrayConstructor(tag) {
+    switch (tag) {
+        case Tag.DATAVIEW:
+            return DataView;
+        case Tag.FLOAT32:
+            return Float32Array;
+        case Tag.FLOAT64:
+            return Float64Array;
+        case Tag.INT8:
+            return Int8Array;
+        case Tag.INT16:
+            return Int16Array;
+        case Tag.INT32:
+            return Int32Array;
+        case Tag.UINT8:
+            return Uint8Array;
+        case Tag.UINT8CLAMPED:
+            return Uint8ClampedArray;
+        case Tag.UINT16:
+            return Uint16Array;
+        case Tag.UINT32:
+            return Uint32Array;
+        case Tag.BIGINT64:
+            return BigInt64Array;
+        case Tag.BIGUINT64:
+            return BigUint64Array;
+
+        // TypeScript notices that this function would return `undefined` if 
+        // none of the previous cases are hit. However, this function is only 
+        // called if `isTypedArray` is true, so this default case will never 
+        // happen in practice. This is just to keep TypeSceript happy.
+        default:
+            return DataView;
+    }
+}
+
+/**
+ * Whether the provided value is iterable.
+ * See https://stackoverflow.com/a/32538867/22334683.
+ * @param {any} value 
+ * The value whose iterability will be checked.
+ * @returns {boolean}
+ */
+export function isIterable(value) {
+    if (typeof value === "string") return true;
+    if (value === null || typeof value !== "object" ) return false;
+    return typeof value[Symbol.iterator] === "function";
+}
+
+/**
+ * Gets the appropriate error constructor for the error name.
+ * 
+ * I could not find a way to type this without using `any`. Forgive me. 
  * @param {any} [value]
  * The object itself. This is necessary to correctly find constructors for 
  * various Error subclasses.
  * @param {(error: Error) => any} [log]
  * An optional logging function.
- * @returns {any}
+ * @returns {import("./private-types.js").AtomicErrorConstructor}
  */
-export function getConstructor(tag, value, log) {
-    if (tag === Tag.ERROR) {
-        const name = Object.getPrototypeOf(value).name;
-        switch (name) {
-            case "AggregateError":
-                return AggregateError;
-            case "EvalError":
-                return EvalError;
-            case "RangeError":
-                return RangeError;
-            case "ReferenceError":
-                return ReferenceError;
-            case "SyntaxError":
-                return SyntaxError;
-            case "TypeError":
-                return TypeError;
-            case "URIError":
-                return URIError;
-            default:
-                if (log !== undefined)
-                    log(getWarning("Cloning error with unrecognized name " + 
-                                   `${name}! It will be cloned into an ` + 
-                                   "ordinary Error object."))
-                return Error;
-        }
+export function getAtomicErrorConstructor(value, log) {
+    const name = Object.getPrototypeOf(value).name;
+    switch (name) {
+        case "Error":
+            return Error;
+        case "EvalError":
+            return EvalError;
+        case "RangeError":
+            return RangeError;
+        case "ReferenceError":
+            return ReferenceError;
+        case "SyntaxError":
+            return SyntaxError;
+        case "TypeError":
+            return TypeError;
+        case "URIError":
+            return URIError;
+        default:
+            if (log !== undefined)
+                log(getWarning("Cloning error with unrecognized name " + 
+                                `${name}! It will be cloned into an ` + 
+                                "ordinary Error object."))
+            return Error;
     }
-    return prototypeMap[tag];
 }
 
 /**

--- a/clone-deep-helpers.js
+++ b/clone-deep-helpers.js
@@ -196,9 +196,11 @@ export function getTag(value) {
  * Gets the appropriate TypedArray constructor for the given object tag.
  * @param {string} tag
  * The tag for the object.
+ * @param {import("./public-types").Log} log
+ * A logging function.
  * @returns {import("./private-types").TypedArrayConstructor}
  */
-export function getTypedArrayConstructor(tag) {
+export function getTypedArrayConstructor(tag, log) {
     switch (tag) {
         case Tag.DATAVIEW:
             return DataView;
@@ -224,12 +226,9 @@ export function getTypedArrayConstructor(tag) {
             return BigInt64Array;
         case Tag.BIGUINT64:
             return BigUint64Array;
-
-        // TypeScript notices that this function would return `undefined` if 
-        // none of the previous cases are hit. However, this function is only 
-        // called if `isTypedArray` is true, so this default case will never 
-        // happen in practice. We include it only to keep TypeScript happy.
         default:
+            log(getWarning("Unrecognized TypedArray subclass. This object " + 
+                           "will be cloned into a DataView instance."));
             return DataView;
     }
 }
@@ -331,26 +330,24 @@ export const Warning = {
         "value as the original Promise.")
 }
 
+const TypedArrayProto = Object
+    .getPrototypeOf(Object
+        .getPrototypeOf(new Float32Array(new ArrayBuffer(0))));
+
 /**
- * Returns `true` if tag is that of a TypedArray subclass, `false` otherwise.
- * @param {string} tag A tag. See {@link tagOf}.
+ * Returns `true` if given value is a TypedArray instance, `false` otherwise.
+ * @param {string} value 
+ * Any arbitrary value
  * @returns {boolean}
  */
-export function isTypedArray(tag) {
-    return [   
-        Tag.DATAVIEW, 
-        Tag.FLOAT32,
-        Tag.FLOAT64,
-        Tag.INT8,
-        Tag.INT16,
-        Tag.INT32,
-        Tag.UINT8,
-        Tag.UINT8CLAMPED,
-        Tag.UINT16,
-        Tag.UINT32,
-        Tag.BIGINT64,
-        Tag.BIGUINT64
-    ].includes(tag);
+export function isTypedArray(value) {
+    try {
+        TypedArrayProto.lastIndexOf.call(value);
+        return true;
+    }
+    catch(_) {
+        return false;
+    }
 }
 
 /** Used to create methods for cloning objects.*/

--- a/clone-deep-utils.js
+++ b/clone-deep-utils.js
@@ -12,11 +12,11 @@ import cloneDeep from "./clone-deep.js";
  * stops if it reaches any prototype with methods.
  * @param {import("./public-types.js").Customizer} options.customizer 
  * See the documentation for `cloneDeep`.
+ * @param {boolean} options.ignoreCloningMethods
+ * See the documentation for `cloneDeep`.
  * @param {import("./public-types.js").Log} options.log 
  * See the documentation for `cloneDeep`.
  * @param {string} options.logMode 
- * See the documentation for `cloneDeep`.
- * @param {boolean} options.useExperimentalTypeChecking
  * See the documentation for `cloneDeep`.
  * @param {boolean} options.letCustomizerThrow 
  * See the documentation for `cloneDeep`.

--- a/clone-deep-utils.js
+++ b/clone-deep-utils.js
@@ -10,7 +10,7 @@ import cloneDeep from "./clone-deep.js";
  * @param {import("./public-types.js").CloneDeepFullyOptions|import("./public-types.js").Customizer} [options] 
  * If a function, it is used as the customizer for the clone. 
  * @param {object} [options] 
- * If an object, it is used as a configuration object.See the documentation for 
+ * If an object, it is used as a configuration object. See the documentation for 
  * `cloneDeep`.
  * @param {boolean} options.force 
  * If `true`, prototypes with methods will be cloned. Normally, this function 

--- a/clone-deep-utils.js
+++ b/clone-deep-utils.js
@@ -2,8 +2,13 @@ import cloneDeep from "./clone-deep.js";
 
 /**
  * Deeply clones the provided object and its prototype chain.
- * @param {any} value The object to clone.
- * @param {import("./public-types.js").CloneDeepFullyOptions|import("./public-types.js").Customizer} [options] If a function, it is used as the customizer for the clone. 
+ * @template T
+ * See the documentation for `cloneDeep`.
+ * @template [U = T]
+ * See the documentation for `cloneDeep`.
+ * @param {T} value The object to clone.
+ * @param {import("./public-types.js").CloneDeepFullyOptions|import("./public-types.js").Customizer} [options] 
+ * If a function, it is used as the customizer for the clone. 
  * @param {object} [options] 
  * If an object, it is used as a configuration object.See the documentation for 
  * `cloneDeep`.
@@ -20,7 +25,7 @@ import cloneDeep from "./clone-deep.js";
  * See the documentation for `cloneDeep`.
  * @param {boolean} options.letCustomizerThrow 
  * See the documentation for `cloneDeep`.
- * @returns {any} The deep copy.
+ * @returns {U} The deep copy.
  */
 export function cloneDeepFully(value, options) {
     if (!["object", "function"].includes(typeof options)) 
@@ -52,9 +57,13 @@ export function cloneDeepFully(value, options) {
         return getAllPropertiesOf(o).some(key => typeof o[key] === "function");
     }
 
+    /** @type {U} */
     const clone = cloneDeep(value, options);
     
+    /** @type {any} */
     let tempClone = clone;
+
+    /** @type {any} */
     let tempOrig = value;
     
     while (tempOrig !== null && ["object", "function"].includes(typeof tempOrig)

--- a/clone-deep.js
+++ b/clone-deep.js
@@ -1,12 +1,14 @@
 import { 
     getTag, 
-    getConstructor, 
+    getAtomicErrorConstructor, 
+    getTypedArrayConstructor,
     Tag, 
     supportedPrototypes, 
     forbiddenProps,
     getWarning,
     Warning,
-    isTypedArray
+    isTypedArray,
+    isIterable
 } from "./clone-deep-helpers.js";
 
 /** 
@@ -18,7 +20,11 @@ const TOP_LEVEL = Symbol("TOP_LEVEL");
 
 /**
  * Clones the provided value.
- * @param {any} _value 
+ * @template T
+ * See CloneDeep.
+ * @template [U = T]
+ * See CloneDeep.
+ * @param {T} _value 
  * The value to clone.
  * @param {import("./public-types").Customizer|undefined} customizer 
  * A customizer function.
@@ -26,7 +32,7 @@ const TOP_LEVEL = Symbol("TOP_LEVEL");
  * Receives an error object for logging.
  * @param {boolean} doThrow 
  * Whether errors in the customizer should cause the function to throw.
- * @returns {any}
+ * @returns {U}
  */
 function cloneInternalNoRecursion(_value, 
                                   customizer, 
@@ -311,7 +317,8 @@ function cloneInternalNoRecursion(_value,
 
             else if ([Tag.BOOLEAN, Tag.DATE].includes(tag)) {
                 /** @type {BooleanConstructor|DateConstructor} */
-                const BooleanOrDateConstructor = getConstructor(tag);
+                const BooleanOrDateConstructor = tag === Tag.DATE ?
+                    Date : Boolean;
 
                 cloned = assign(new BooleanOrDateConstructor(Number(value)), 
                                 parentOrAssigner, 
@@ -320,7 +327,8 @@ function cloneInternalNoRecursion(_value,
             }
             else if ([Tag.NUMBER, Tag.STRING].includes(tag)) {
                 /** @type {NumberConstructor|StringConstructor} */
-                const NumberOrStringConstructor = getConstructor(tag);
+                const NumberOrStringConstructor = tag === Tag.NUMBER ?
+                    Number : String;
 
                 cloned = assign(new NumberOrStringConstructor(value), 
                                 parentOrAssigner, 
@@ -364,13 +372,36 @@ function cloneInternalNoRecursion(_value,
                 /** @type {Error} */
                 const error = value;
 
-                /** @type {ErrorConstructor} */
-                const ErrorConstructor = getConstructor(tag, error, log);
+                /** @type {Error} */
+                let clonedError;
 
-                const cause = error.cause;
-                const clonedError = cause === undefined
-                    ? new ErrorConstructor(error.message)
-                    : new ErrorConstructor(error.message, { cause });
+                if (Object.getPrototypeOf(value).name === "AggregateError") {
+
+                    const errors = isIterable(value.errors) ? value.errors : [];
+
+                    if (!isIterable(value.errors))
+                        log(getWarning("Cloning AggregateError with" + 
+                                       "non-iterable errors property. It " +
+                                       "will be cloned into an " + 
+                                       "AggregateError instance with an " + 
+                                       "empty aggregation."));
+                    else propsToIgnore.push("errors");
+
+                    const cause = error.cause;
+                    clonedError = cause === undefined
+                        ? new AggregateError(errors, error.message)
+                        : new AggregateError(errors, error.message, { cause });
+                }
+                else {
+                    /** @type {import("./private-types.js").AtomicErrorConstructor} */
+                    const ErrorConstructor = getAtomicErrorConstructor(error, 
+                                                                       log);
+
+                    const cause = error.cause;
+                    clonedError = cause === undefined
+                        ? new ErrorConstructor(error.message)
+                        : new ErrorConstructor(error.message, { cause });
+                }
 
                 const defaultDescriptor = Object.getOwnPropertyDescriptor(
                     new Error, "stack");
@@ -386,7 +417,7 @@ function cloneInternalNoRecursion(_value,
 
                 cloned = assign(clonedError, parentOrAssigner, prop, metadata);
 
-                propsToIgnore.push("cause", "stack");
+                propsToIgnore.push("stack");
             }
 
             else if (Tag.ARRAYBUFFER === tag) {
@@ -398,7 +429,7 @@ function cloneInternalNoRecursion(_value,
             
             else if (isTypedArray(tag)) {
                 /** @type {import("./private-types").TypedArrayConstructor} */
-                const TypedArray = getConstructor(tag);
+                const TypedArray = getTypedArrayConstructor(tag);
 
                 // copy data over to clone
                 const buffer = new ArrayBuffer(
@@ -419,11 +450,7 @@ function cloneInternalNoRecursion(_value,
                 /** @type {Map<any, any>} */
                 const originalMap = value;
 
-                /** @type {MapConstructor} */
-                const MapConstructor = getConstructor(tag);
-
-                const cloneMap = new MapConstructor;
-
+                const cloneMap = new Map;
                 cloned = assign(cloneMap, parentOrAssigner, prop, metadata);
 
                 originalMap.forEach((subValue, key) => {
@@ -443,11 +470,7 @@ function cloneInternalNoRecursion(_value,
                 /** @type {Set<any>} */
                 const originalSet = value;
 
-                /** @type {SetConstructor} */
-                const SetConstructor = getConstructor(tag);
-
-                const cloneSet = new SetConstructor;
-
+                const cloneSet = new Set;
                 cloned = assign(cloneSet, parentOrAssigner, prop, metadata);
 
                 originalSet.forEach(subValue => {
@@ -546,7 +569,13 @@ function cloneInternalNoRecursion(_value,
 }
 
 /**
- * @param {any} value The value to deeply copy.
+ * @template T
+ * The type of the input value.
+ * @template [U = T]
+ * The type of the return value. By default, it is the same as the input value. 
+ * Nefarious customizer usage could require them be distinct, however. Please do 
+ * not do this.
+ * @param {T} value The value to deeply copy.
  * @param {import("./public-types").CloneDeepOptions|import("./public-types").Customizer} [optionsOrCustomizer] 
  * If a function, this argument is used as the customizer.
  * @param {object} [optionsOrCustomizer] 
@@ -567,7 +596,7 @@ function cloneInternalNoRecursion(_value,
  * If `true`, errors thrown by the customizer will be thrown by `cloneDeep`. By 
  * default, the error is logged and the algorithm proceeds with default 
  * behavior.
- * @returns {Object} The deep copy.
+ * @returns {U} The deep copy.
  */
 function cloneDeep(value, optionsOrCustomizer) {
     /** @type {import("./public-types").Customizer|undefined} */

--- a/clone-deep.js
+++ b/clone-deep.js
@@ -318,8 +318,9 @@ function cloneInternalNoRecursion(_value,
 
             else if ([Tag.BOOLEAN, Tag.DATE].includes(tag)) {
                 /** @type {BooleanConstructor|DateConstructor} */
-                const BooleanOrDateConstructor = tag === Tag.DATE ?
-                    Date : Boolean;
+                const BooleanOrDateConstructor = tag === Tag.DATE 
+                    ? Date 
+                    : Boolean;
 
                 cloned = assign(new BooleanOrDateConstructor(Number(value)), 
                                 parentOrAssigner, 
@@ -328,8 +329,9 @@ function cloneInternalNoRecursion(_value,
             }
             else if ([Tag.NUMBER, Tag.STRING].includes(tag)) {
                 /** @type {NumberConstructor|StringConstructor} */
-                const NumberOrStringConstructor = tag === Tag.NUMBER ?
-                    Number : String;
+                const NumberOrStringConstructor = tag === Tag.NUMBER 
+                    ? Number 
+                    : String;
 
                 cloned = assign(new NumberOrStringConstructor(value), 
                                 parentOrAssigner, 
@@ -374,21 +376,26 @@ function cloneInternalNoRecursion(_value,
                 /** @type {Error} */
                 let clonedError;
 
-                if (value.name === "AggregateError") {
+                if (error.name === "AggregateError") {
+                    /** @type {AggregateError} */
+                    const aggregateError = value;
 
-                    const errors = isIterable(value.errors) ? value.errors : [];
+                    const errors = isIterable(aggregateError.errors) 
+                        ? aggregateError.errors 
+                        : [];
 
-                    if (!isIterable(value.errors))
+                    if (!isIterable(aggregateError.errors))
                         log(getWarning("Cloning AggregateError with" + 
                                        "non-iterable errors property. It " +
                                        "will be cloned into an " + 
                                        "AggregateError instance with an " + 
                                        "empty aggregation."));
                     
-                    const cause = error.cause;
+                    const cause = aggregateError.cause;
+                    const message = aggregateError.message;
                     clonedError = cause === undefined
-                        ? new AggregateError(errors, error.message)
-                        : new AggregateError(errors, error.message, { cause });
+                        ? new AggregateError(errors, message)
+                        : new AggregateError(errors, message, { cause });
                 }
                 else {
                     /** @type {import("./private-types.js").AtomicErrorConstructor} */

--- a/clone-deep.js
+++ b/clone-deep.js
@@ -374,7 +374,7 @@ function cloneInternalNoRecursion(_value,
                 /** @type {Error} */
                 let clonedError;
 
-                if (Object.getPrototypeOf(value).name === "AggregateError") {
+                if (value.name === "AggregateError") {
 
                     const errors = isIterable(value.errors) ? value.errors : [];
 

--- a/clone-deep.js
+++ b/clone-deep.js
@@ -41,11 +41,11 @@ const TOP_LEVEL = Symbol("TOP_LEVEL");
  * @returns {U}
  */
 export function cloneInternalNoRecursion(_value, 
-                                  customizer, 
-                                  log,
-                                  ignoreCloningMethods, 
-                                  doThrow,
-                                  parentObjectRegistry) {
+                                         customizer, 
+                                         log,
+                                         ignoreCloningMethods, 
+                                         doThrow,
+                                         parentObjectRegistry) {
 
     /**
      * Handles the assignment of the cloned value to some persistent place.
@@ -442,7 +442,7 @@ export function cloneInternalNoRecursion(_value,
                         : [];
 
                     if (!isIterable(aggregateError.errors))
-                        log(getWarning("Cloning AggregateError with" + 
+                        log(getWarning("Cloning AggregateError with " + 
                                        "non-iterable errors property. It " +
                                        "will be cloned into an " + 
                                        "AggregateError instance with an " + 

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
 import cloneDeep from "./clone-deep.js";
 export { cloneDeepFully, useCustomizers } from "./clone-deep-utils.js";
+export { CLONE } from "./clone-deep-helpers.js";
 export default cloneDeep;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "cms-clone-deep",
   "repository": "https://github.com/calebmsword/clone-deep",
   "type": "module",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "description": "A dependency-free utility for deeply cloning JavaScript objects.",
   "main": "index.js",
   "types": "public-types.d.ts",

--- a/private-types.d.ts
+++ b/private-types.d.ts
@@ -24,3 +24,12 @@ export type TypedArrayConstructor =
     Uint32ArrayConstructor |
     BigInt64ArrayConstructor |
     BigUint64ArrayConstructor;
+
+export type AtomicErrorConstructor = 
+    ErrorConstructor | 
+    EvalErrorConstructor | 
+    RangeErrorConstructor | 
+    ReferenceErrorConstructor | 
+    SyntaxErrorConstructor | 
+    TypeErrorConstructor | 
+    URIErrorConstructor;

--- a/public-types.d.ts
+++ b/public-types.d.ts
@@ -8,7 +8,7 @@ export interface ValueTransform {
     additionalValues?: AdditionalValue[],
     ignore?: boolean,
     ignoreProps?: boolean,
-    ignoreProto?: boolean
+    ignoreProto?: boolean,
 }
 
 export type Customizer = (value: any) => ValueTransform|void;

--- a/public-types.d.ts
+++ b/public-types.d.ts
@@ -30,7 +30,8 @@ export interface CloneDeepFullyOptions extends CloneDeepOptions {
 export interface CloneMethodResult<T> {
     clone: T
     propsToIgnore?: (string|symbol)[]
-    ignoreProps?: boolean
+    ignoreProps?: boolean,
+    ignoreProto: true
 }
 
 declare module "cms-clone-deep" {

--- a/public-types.d.ts
+++ b/public-types.d.ts
@@ -18,6 +18,7 @@ export type Log = (error: Error) => any;
 export interface CloneDeepOptions {
     customizer?: Customizer
     log?: Log,
+    ignoreCloningMethods?: boolean
     logMode?: string
     letCustomizerThrow?: boolean
 }
@@ -26,6 +27,11 @@ export interface CloneDeepFullyOptions extends CloneDeepOptions {
     force?: boolean
 }
 
+export interface CloneMethodResult<T> {
+    clone: T
+    propsToIgnore?: (string|symbol)[]
+    ignoreProps?: boolean
+}
 
 declare module "cms-clone-deep" {
 
@@ -178,8 +184,7 @@ declare module "cms-clone-deep" {
  * @param {Customizer} optionsOrCustomizer.customizer 
  * Allows the user to inject custom logic. The function is given the value to 
  * copy. If the function returns an object, the value of the `clone` property on 
- * that object will be used as the clone. See the documentation for `cloneDeep` 
- * for more information.
+ * that object will be used as the clone.
  * @param {Log} optionsOrCustomizer.log 
  * Any errors which occur during the algorithm can optionally be passed to a log 
  * function. `log` should take one argument which will be the error encountered. 
@@ -188,10 +193,13 @@ declare module "cms-clone-deep" {
  * Case-insensitive. If "silent", no warnings will be logged. Use with caution, 
  * as failures to perform true clones are logged as warnings. If "quiet", the 
  * stack trace of the warning is ignored.
+ * @param {boolean} optionsOrCustomizer.ignoreCloningMethods 
+ * If true, cloning methods asociated with an object will not be used to clone 
+ * the object.
  * @param {boolean} optionsOrCustomizer.letCustomizerThrow 
- * If `true`, errors 
- * thrown by the customizer will be thrown by `cloneDeep`. By default, the error 
- * is logged and the algorithm proceeds with default behavior.
+ * If `true`, errors thrown by the customizer will be thrown by `cloneDeep`. By 
+ * default, the error is logged and the algorithm proceeds with default 
+ * behavior.
  * @returns {Object} 
  * The deep copy.
  */
@@ -200,7 +208,7 @@ export default function cloneDeep(
     optionsOrCustomizer: CloneDeepOptions|Customizer|undefined
 ) : any;
     
-    /**
+/**
  * Deeply clones the provided object and its prototype chain.
  * @param {any} value 
  * The object to clone.
@@ -217,6 +225,8 @@ export default function cloneDeep(
  * @param {Log} options.log 
  * See the documentation for `cloneDeep`.
  * @param {string} options.logMode 
+ * See the documentation for `cloneDeep`.
+ * @param {boolean} optionsOrCustomizer.ignoreCloningMethods 
  * See the documentation for `cloneDeep`.
  * @param {boolean} options.letCustomizerThrow 
  * See the documentation for `cloneDeep`.

--- a/public-types.d.ts
+++ b/public-types.d.ts
@@ -26,7 +26,6 @@ export interface CloneDeepFullyOptions extends CloneDeepOptions {
     force?: boolean
 }
 
-
 declare module "cms-clone-deep" {
 
 /**
@@ -170,7 +169,14 @@ declare module "cms-clone-deep" {
  * for example, use it to throw if the user tries to clone functions, 
  * `WeakMaps`, or `WeakSets`).
  * 
- * @param {any} value The value to deeply copy.
+ * @template T
+ * The type of the input value.
+ * @template [U = T]
+ * The type of the return value. By default, it is the same as the input value. 
+ * Nefarious customizer usage could require the be distinct, however. Please do 
+ * not do this.
+ * 
+ * @param {T} value The value to deeply copy.
  * @param {CloneDeepOptions|Customizer} [optionsOrCustomizer] 
  * If a function, this argument is used as the customizer.
  * @param {object} [optionsOrCustomizer] 
@@ -192,16 +198,22 @@ declare module "cms-clone-deep" {
  * If `true`, errors 
  * thrown by the customizer will be thrown by `cloneDeep`. By default, the error 
  * is logged and the algorithm proceeds with default behavior.
- * @returns {Object} 
+ * @returns {U} 
  * The deep copy.
  */
-export default function cloneDeep(
-    value: any, 
+export default function cloneDeep<T, U = T>(
+    value: T, 
     optionsOrCustomizer: CloneDeepOptions|Customizer|undefined
-) : any;
+) : U;
     
     /**
  * Deeply clones the provided object and its prototype chain.
+ * @template T
+ * The type of the input value.
+ * @template [U = T]
+ * The type of the return value. By default, it is the same as the input value. 
+ * Nefarious customizer usage could require the be distinct, however. Please do 
+ * not do this.
  * @param {any} value 
  * The object to clone.
  * @param {CloneDeepFullyOptions|Customizer} [optionsOrCustomizer] 
@@ -223,10 +235,10 @@ export default function cloneDeep(
  * @returns {any} 
  * The deep copy.
  */
-export function cloneDeepFully(
-    value: any,
+export function cloneDeepFully<T, U = T>(
+    value: T,
     optionsOrCustomizer: CloneDeepFullyOptions|Customizer|undefined
-) : any;
+) : U;
 
 /**
  * Creates a customizer which composes other customizers.

--- a/public-types.d.ts
+++ b/public-types.d.ts
@@ -173,9 +173,8 @@ declare module "cms-clone-deep" {
  * the check for circular references. 
  * 
  * The best use of the customizer to support user-made types. You can also use 
- * it to override some of the design decisions made in the algorithm (you could, 
- * for example, use it to throw if the user tries to clone functions, 
- * `WeakMaps`, or `WeakSets`).
+ * it to override some of the design decisions made in the algorithm (say, 
+ * ignore all non-enumerable properties of an object).
  * 
  * @template T
  * The type of the input value.

--- a/public-types.d.ts
+++ b/public-types.d.ts
@@ -205,17 +205,10 @@ declare module "cms-clone-deep" {
  * If true, cloning methods asociated with an object will not be used to clone 
  * the object.
  * @param {boolean} optionsOrCustomizer.letCustomizerThrow 
-<<<<<<< HEAD
  * If `true`, errors thrown by the customizer will be thrown by `cloneDeep`. By 
  * default, the error is logged and the algorithm proceeds with default 
  * behavior.
- * @returns {Object} 
-=======
- * If `true`, errors 
- * thrown by the customizer will be thrown by `cloneDeep`. By default, the error 
- * is logged and the algorithm proceeds with default behavior.
  * @returns {U} 
->>>>>>> dev
  * The deep copy.
  */
 export default function cloneDeep<T, U = T>(

--- a/test.js
+++ b/test.js
@@ -4,7 +4,8 @@ import { describe, mock, test } from "node:test";
 import { 
     Tag, 
     supportedPrototypes, 
-    forbiddenProps 
+    forbiddenProps, 
+    CLONE
 } from "./clone-deep-helpers.js";
 import  cloneDeep from "./clone-deep.js";
 import { cloneDeepFully, useCustomizers } from "./clone-deep-utils.js";
@@ -1273,6 +1274,23 @@ try {
         });
     });
 
+    describe("CLONE", () => {
+        test("CLONE can customize the clone", () => {
+            // -- arrange
+
+            // -- act
+
+            // -- assert
+        });
+
+        test("CLONE can ", () => {
+            // -- arrange
+
+            // -- act
+
+            // -- assert
+        });
+    });
 
 }
 catch(error) {

--- a/test.js
+++ b/test.js
@@ -1275,7 +1275,8 @@ try {
     });
 
     describe("CLONE", () => {
-        test("CLONE can customize the clone", () => {
+        test("classes can use the CLONE symbol to create a method " + 
+             "responsible for defining the clone of their instances", () => {
             // -- arrange
 
             // -- act
@@ -1283,7 +1284,35 @@ try {
             // -- assert
         });
 
-        test("CLONE can ", () => {
+        test("cloning methods can be ignored entirely if the correct option " + 
+             "is used", () => {
+            // -- arrange
+
+            // -- act
+
+            // -- assert
+        });
+
+        test("cloning methods can be ignored entirely if the correct option " + 
+             "is used", () => {
+            // -- arrange
+
+            // -- act
+
+            // -- assert
+        });
+        
+        test("cloning methods can cause the algorithm to not recurse on " + 
+             "specific properties on the clone", () => {
+            // -- arrange
+
+            // -- act
+
+            // -- assert
+        });
+
+        test("cloning methods can be fully responsible for cloning all " + 
+             "properties of the resultant clone", () => {
             // -- arrange
 
             // -- act

--- a/test.js
+++ b/test.js
@@ -637,10 +637,7 @@ try {
             try {
                 // -- arrange
                 class TestError extends Error {
-                    constructor(...args) {
-                        super(...args);
-                        getProto(this).name = "TestError";
-                    }
+                    name = "TestError";
                 };
 
                 const log = mock.fn(() => {});
@@ -767,7 +764,8 @@ try {
             });
         });
 
-        test('functions become empty objects inheriting Function.prototype', () => {
+        test("functions become empty objects inheriting " + 
+             "Function.prototype", () => {
             [function() {}, () => {}].forEach(func => {
                 // -- act
                 const cloned = cloneDeep(func);
@@ -872,6 +870,19 @@ try {
                 temporarilyMonkeypatch = false;
                 throw error;
             }
+        });
+
+        test("regExp.lastIndex is cloned properly", () => {
+            // -- arrange
+            const regExp = new RegExp("");
+            regExp.lastIndex = {};
+
+            // -- act
+            const cloned = cloneDeep(regExp);
+
+            // -- assert
+            assert.deepEqual(cloned.lastIndex, regExp.lastIndex);
+            assert.notStrictEqual(cloned.lastIndex, regExp.lastIndex);
         });
 
         test("Native prototypes can be cloned without errors", () => {

--- a/test.js
+++ b/test.js
@@ -548,6 +548,26 @@ try {
             assert.strictEqual(cloned.stack, error.stack);
         });
 
+        test("Error stacks are cloned correctly", () => {
+            // -- arrange
+            const error = new Error("");
+            const errorStackReassigned = new Error("");
+            errorStackReassigned.stack = Object.preventExtensions({});
+
+            // -- act
+            const cloned = cloneDeep(error);
+            const clonedStackReassigned = cloneDeep(errorStackReassigned);
+
+            // -- assert
+            assert.strictEqual(cloned.stack, error.stack);
+            assert.notStrictEqual(clonedStackReassigned.stack, 
+                                  errorStackReassigned.stack);
+            assert.deepEqual(clonedStackReassigned.stack, 
+                             errorStackReassigned.stack);
+            assert.strictEqual(Object.isExtensible(clonedStackReassigned.stack), 
+                               false);
+        })
+
         test("Errors are cloned correctly even if monkeypatched", () => {
             let doMonkeypatch = true;
             try {
@@ -666,9 +686,14 @@ try {
                 const cloned = cloneDeep(error);
 
                 // -- assert
-                assert.strictEqual(cloned !== error, true);
-                assert.strictEqual(cloned.errors !== error.errors, true);
+                assert.notStrictEqual(cloned, error);
+                assert.notStrictEqual(cloned.errors, error.errors);
                 assert.deepEqual(cloned, error);
+                cloned.errors.forEach((clonedError, i) => {
+                    const originalError = error.errors[i];
+                    assert.notStrictEqual(clonedError, originalError);
+                    assert.deepEqual(clonedError, originalError);
+                });
             });
 
             test("AggregateError with cause is handled", () => {

--- a/test.js
+++ b/test.js
@@ -1560,10 +1560,10 @@ try {
                                           "strings or symbols"));
         });
 
-        test("if using cloneDeepFully and observing cloning methods, then " + 
-             "any prototype containing a cloning method used for an instance " + 
-             "cloned previously in the chain will not be cloned using its " + 
-             "cloning method", () => {
+        test("if using cloneDeepFully in force mode and observing cloning " + 
+             "methods, then any prototype containing a cloning method used " + 
+             "for an instance cloned previously in the chain will not be " + 
+             "cloned using its cloning method", () => {
             // -- arrange
             class Test {
                 [CLONE]() {
@@ -1592,9 +1592,9 @@ try {
             assert.strictEqual(getProto(cloned2).test, undefined);
         });
 
-        test("If using cloneDeepFully and observing cloning methods, objects " + 
-             "NOT instantiated as a class will have their prototype use its " + 
-             "cloning method", () => {
+        test("If using cloneDeepFully in force mode and observing cloning " + 
+             "methods, objects NOT instantiated as a class will have their " + 
+             "prototype use its cloning method", () => {
             // -- arrange
             const c = {
                 [CLONE]() {


### PR DESCRIPTION
This new version includes:
 - objects can now define how they are cloned by using a method with a symbol provided from this package
 - fixed bug where AggregateErrors were cloned as if the constructor API was the same as the other Error classes
 - constructors for various native classes are acquired without the usage of the `constructor` property, which avoids bugs where the user provides an object which is a native class instance with an overridden `constructor` property
 - cloneDeep and cloneDeepFully can be typed with generics now to indicate the input and output variables (the output is by default the same as the input, be we allow a second generic to the represent the return type since customizer and clone method usage can result in clones that are different types from the original)
 - Internally, the algorithm call methods on the prototypes for native classes, combined with `call`, to determine the type of something whenever possible. This is a stronger type-check that Object.prototype.toString.call since the latter can be easily broken with Symbol.toStringTag usage, while breaking the prototype approach requires monkeypatching fundamental JavaScript prototypes (a much greater offense). The only supported types for which this does not work are the TypeArray subclasses, in which case Object.prototype.toString.call is used to differentiate them.
 - fixed bug where some properties on native class instances were not recursed on, meaning they would not be cloned propertly if reassigned to any non-primitive
 - some exported types have been updated to reflect the changes.
 - various documentation improvements to README and docstrings
 - lots and lots of tests for all the new features