### PR TITLE
no Web APIs in supportedPrototypes

### DIFF
--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -100,15 +100,4 @@ export const supportedPrototypes = Object.freeze([
     Uint32Array.prototype,
     BigInt64Array.prototype,
     BigUint64Array.prototype,
-
-    // Web APIs
-    Blob.prototype,
-    DOMException.prototype,
-    DOMMatrix.prototype,
-    DOMMatrixReadOnly.prototype,
-    DOMPoint.prototype,
-    DOMPointReadOnly.prototype,
-    DOMQuad.prototype,
-    File.prototype,
-    FileList.prototype
 ]);


### PR DESCRIPTION
The supportedPrototypes constant was supposed to have no web APIs. getSupportedPrototypes in helpers would then concatenate supportedPrototypes with any supported Web APIs that were globally accessible in the runtime. But the current dev branch accidentally had Web APIs accessed directly in supportedPrototypes. My bad.