### PR TITLE
benchmark UI updated

### DIFF
--- a/benchmark/benchmark.css
+++ b/benchmark/benchmark.css
@@ -4,7 +4,7 @@
     --content-border-color: black;
     --checkbox-or-radio-border-color: rgb(80, 79, 79);
     --checkbox-or-radio-background-color: rgb(222, 223, 228);
-    --block-thread-color: rgb(169 21 100);
+    --block-thread-color: rgb(152, 17, 89);
     --button-color: rgb(255, 174, 0);
     --button-hover-color: rgb(174, 126, 24);
     --button-border-color: black;
@@ -14,6 +14,8 @@ html, body {
     margin: 0px;
     padding: 0px;
     background-color: var(--main-background-color);
+    display: flex;
+    align-items: flex-start;
 }
 
 .main-container {
@@ -55,10 +57,13 @@ html, body {
     flex-direction: column;
 }
 
-
 .table-col .title {
     flex-grow: 1;
     padding: 20px;
+}
+
+.title-text {
+    font-size: 11px;
 }
 
 .table-col .result {
@@ -178,6 +183,10 @@ html, body {
     align-items: center;
 }
 
+input[type='checkbox'].sync-checkbox {
+    accent-color: var(--block-thread-color);
+}
+
 .checkbox-label {
     padding-left: 6px;
 }
@@ -208,4 +217,8 @@ input[type="radio"] {
 .button.pressable:hover {
     background-color: var(--button-hover-color);
     cursor: pointer;
+}
+
+.button.invisible {
+    display: none;
 }

--- a/benchmark/benchmark.js
+++ b/benchmark/benchmark.js
@@ -2,46 +2,96 @@
 // associated HTML is in index.html. Run `node benchmark\serve.js` in the
 // directory containing index.html and the UI will be hosted at
 // http://localhost:8787.
+import runJob from './run-job.js';
 
 
 // -- constant variables
-const DECIMAL_PLACES = 4;
 const worker = new Worker('benchmark/worker.js');
+const DECIMAL_PLACES = 3;
+const DEFAULT_NUM_ITERATIONS = 1000;
+const DEFAULT_NUM_PROTOTYPES = 1000;
+const TypeChecking = Object.freeze({
+    DEFAULT: 'DEFAULT',
+    ROBUST: 'ROBUST'
+});
 
 
 // -- stateful variables
-let numIterations = 1000;
+let numIterations = DEFAULT_NUM_ITERATIONS;
+let numPrototypes = DEFAULT_NUM_PROTOTYPES;
 let benchmarking = false;
+let ignoreCircularReferences = false;
+let ignorePropertyDescriptors = false;
+let ignoreMetadata = false;
+let typeChecking = TypeChecking.DEFAULT;
+let block = false;
+let elementUnderCursor;
 
 
 // -- DOM elements
 const structuredCloneResult = document.querySelector('.top .result-text');
+const lodashResult = document.querySelector('.lodash .result-text');
+const cloneResult = document.querySelector('.clone .result-text');
+const esToolkitResult = document.querySelector('.es .result-text');
 const cloneDeepResult = document.querySelector('.bottom .result-text');
+const protoResult = document.querySelector('.proto .result-text');
+
+const circularCheckbox = document.querySelector('#ignoreCircular');
+const descriptorCheckbox = document.querySelector('#ignoreDesc');
+const metadataCheckbox = document.querySelector('#ignoreMeta');
+
+const radioDefault = document.querySelector('#default');
+const radioRobust = document.querySelector('#robust');
+
+const syncCheckbox = document.querySelector('.sync-checkbox');
+
+const iterationsInput = document.querySelector('.iterations');
+const prototypesInput = document.querySelector('.prototypes');
 
 const primitivesOnlyButton = document.querySelector('.button.primitives-only');
 const ordinaryObjectButton = document.querySelector('.button.ordinary-object');
 const deeplyNestedButton = document.querySelector('.button.deeply-nested');
+const protoChainButton = document.querySelector('.button.prototype-chain');
 
-const textinput = document.querySelector('.iterations');
+const radioButtons = [
+    radioDefault,
+    radioRobust
+];
 
 const buttons = [
     primitivesOnlyButton,
     ordinaryObjectButton,
-    deeplyNestedButton
+    deeplyNestedButton,
+    protoChainButton
 ];
+
+const radioToTypeChecking = new Map([
+    [radioDefault, TypeChecking.DEFAULT],
+    [radioRobust, TypeChecking.ROBUST]
+]);
 
 
 // -- helper functions
-const assignValues = (values) => {
-    const [sc, cd] = values.map((number) => {
+const assignValues = (values, type) => {
+    if (type === 'prototype') {
+        protoResult.textContent = String(values[0].toFixed(DECIMAL_PLACES));
+        return;
+    }
+
+    const [sc, ld, cl, es, cd] = values.map((number) => {
         return number.toFixed(DECIMAL_PLACES);
     });
     structuredCloneResult.textContent = String(sc);
+    lodashResult.textContent = String(ld);
+    cloneResult.textContent = String(cl);
+    esToolkitResult.textContent = String(es);
     cloneDeepResult.textContent = String(cd);
 };
 
 const doBenchmark = (type) => {
     benchmarking = true;
+
+    const oldCursorStyle = elementUnderCursor.style.cursor;
 
     document.body.style.cssText = 'cursor: wait !important';
 
@@ -49,27 +99,93 @@ const doBenchmark = (type) => {
         element.classList.remove('pressable');
     });
 
-    worker.onmessage = ({ data }) => {
-        const { result } = data;
-
+    const cleanup = (result) => {
         document.body.style.cssText = 'auto';
+        elementUnderCursor.style.cursor = oldCursorStyle;
 
         buttons.forEach((element) => {
             element.classList.add('pressable');
         });
 
-        assignValues(result);
-
         benchmarking = false;
+
+        assignValues(result, type);
     };
 
-    worker.postMessage({ type, numIterations });
+    const config = {
+        ignoreCircularReferences,
+        ignorePropertyDescriptors,
+        ignoreMetadata,
+        typeChecking
+    };
+
+    if (block) {
+        setTimeout(async () => {
+            cleanup(await runJob(type, numIterations, numPrototypes, config));
+        }, 250);
+
+        return;
+    }
+
+    worker.onmessage = ({ data }) => {
+        cleanup(data.result);
+    };
+
+    worker.postMessage({ type, numIterations, numPrototypes, config });
+};
+
+const updateTypeChecking = (context) => {
+    typeChecking = radioToTypeChecking.get(context.target);
+};
+
+window.getState = () => {
+    [
+        numIterations,
+        numPrototypes,
+        benchmarking,
+        ignoreCircularReferences,
+        ignorePropertyDescriptors,
+        ignoreMetadata,
+        typeChecking,
+        block
+    ].forEach(console.log);
 };
 
 
 // -- event listeners
-textinput.addEventListener('input', (event) => {
-    numIterations = event.target.value || 1000;
+document.onmousemove = (event) => {
+    elementUnderCursor = event.target;
+};
+
+iterationsInput.addEventListener('input', (event) => {
+    numIterations = Number(event.target.value || DEFAULT_NUM_ITERATIONS);
+});
+
+prototypesInput.addEventListener('input', (event) => {
+    numPrototypes = Number(event.target.value || DEFAULT_NUM_PROTOTYPES);
+});
+
+circularCheckbox.addEventListener('change', (event) => {
+    ignoreCircularReferences = event.currentTarget.checked;
+    ignoreCircularReferences
+        ? ordinaryObjectButton.classList.add('invisible')
+        : ordinaryObjectButton.classList.remove('invisible');
+});
+
+descriptorCheckbox.addEventListener('change', (event) => {
+    ignorePropertyDescriptors = event.currentTarget.checked;
+});
+
+metadataCheckbox.addEventListener('change', (event) => {
+    ignoreMetadata = event.currentTarget.checked;
+});
+
+radioButtons.forEach((element) => {
+    element.addEventListener('change', updateTypeChecking);
+});
+
+syncCheckbox.addEventListener('change', (event) => {
+    block = event.currentTarget.checked;
 });
 
 primitivesOnlyButton.addEventListener('click', () => {
@@ -87,5 +203,11 @@ ordinaryObjectButton.addEventListener('click', () => {
 deeplyNestedButton.addEventListener('click', () => {
     if (!benchmarking) {
         doBenchmark('nested');
+    }
+});
+
+protoChainButton.addEventListener('click', () => {
+    if (!benchmarking) {
+        doBenchmark('prototype');
     }
 });

--- a/benchmark/index.html
+++ b/benchmark/index.html
@@ -11,9 +11,9 @@
     
 </head>
 <body>
-    <div class="main-container">
+    <div class="main-container deepClone">
         <div class="table-title-container">
-            <div class="table-title">Average Time:</div>
+            <div class="table-title">Average Time (deep clone):</div>
         </div>
         <div class="table">
             <div class="table-col left">
@@ -44,36 +44,36 @@
                 </div>
             </div>
             <div class="table-col right">
-                <div class="result top">
+                <div class="result sc top">
                     <div class="result-text-container">
-                        <div class="result-text">------</div>
+                        <div class="result-text">-----</div>
                     </div>
                 </div>
-                <div class="result">
+                <div class="result lodash">
                     <div class="result-text-container">
-                        <div class="result-text">------</div>
+                        <div class="result-text">-----</div>
                     </div>
                 </div>
-                <div class="result">
+                <div class="result clone">
                     <div class="result-text-container">
-                        <div class="result-text">------</div>
+                        <div class="result-text">-----</div>
                     </div>
                 </div>
-                <div class="result">
+                <div class="result es">
                     <div class="result-text-container">
-                        <div class="result-text">------</div>
+                        <div class="result-text">-----</div>
                     </div>
                 </div>
                 <div class="result bottom">
                     <div class="result-text-container">
-                        <div class="result-text">------</div>
+                        <div class="result-text">-----</div>
                     </div>
                 </div>
             </div>
         </div>
         <div class="iterations-container">
             <div class= "label-container">
-                <div class="label">Number of iterations:</div>
+                <div class="label">number of iterations:</div>
             </div>
             <div class="input-container">
                 <input class="iterations" type="number" placeholder="1000">
@@ -99,13 +99,9 @@
                 </label>
             </div>
             <div class="type-checking-container">
-                <div class="type-checking">type checking:</div>
+                <div class="type-checking">Type Checking:</div>
             </div>
             <div class="checkbox-or-radio radios">
-                <div class="radio-container">
-                    <input type="radio" id="fast" name="typeChecking" />
-                    <label class="radio-label" for="fast">fast</label>
-                </div>
                 <div class="radio-container">
                     <input type="radio" id="default" name="typeChecking" checked="checked"/>
                     <label class="radio-label" for="default">default</label>
@@ -134,7 +130,41 @@
                 </div>
             </div>
             <div class="button pressable deeply-nested">
-                <div class="button-text">deeply nested (1,000 layers)</div>
+                <div class="button-text">deeply nested (500 layers)</div>
+            </div>
+        </div>
+    </div>
+    <div class="main-container deepCloneFully">
+        <div class="table-title-container">
+            <div class="table-title">Average Time (prototype chain):</div>
+        </div>
+        <div class="table">
+            <div class="table-col left">
+                <div class="title">
+                    <div class="title-text-container top">
+                        <div class="title-text">cloneDeep (ms):</div>
+                    </div>
+                </div>
+            </div>
+            <div class="table-col right">
+                <div class="result proto top">
+                    <div class="result-text-container">
+                        <div class="result-text">-----</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="iterations-container">
+            <div class= "label-container">
+                <div class="label">number of prototypes:</div>
+            </div>
+            <div class="input-container">
+                <input class="prototypes" type="number" placeholder="1000">
+            </div>
+        </div>
+        <div class="buttons">
+            <div class="button pressable prototype-chain">
+                <div class="button-text">clone prototype chain</div>
             </div>
         </div>
     </div>

--- a/benchmark/run-job.js
+++ b/benchmark/run-job.js
@@ -1,6 +1,3 @@
-// eslint-disable-next-line
-const clone = function(){function v(e,t){return null!=t&&e instanceof t}var m,_,h;try{m=Map}catch(e){m=function(){}}try{_=Set}catch(e){_=function(){}}try{h=Promise}catch(e){h=function(){}}function w(e,b,t,y,g){"object"==typeof b&&(t=b.depth,y=b.prototype,g=b.includeNonEnumerable,b=b.circular);var j=[],O=[],d="undefined"!=typeof Buffer;return void 0===b&&(b=!0),void 0===t&&(t=1/0),function o(e,c){if(null===e)return null;if(0===c)return e;var f,t;if("object"!=typeof e)return e;if(v(e,m))f=new m;else if(v(e,_))f=new _;else if(v(e,h))f=new h(function(t,r){e.then(function(e){t(o(e,c-1))},function(e){r(o(e,c-1))})});else if(w.__isArray(e))f=[];else if(w.__isRegExp(e))f=new RegExp(e.source,x(e)),e.lastIndex&&(f.lastIndex=e.lastIndex);else if(w.__isDate(e))f=new Date(e.getTime());else{if(d&&Buffer.isBuffer(e))return f=Buffer.allocUnsafe?Buffer.allocUnsafe(e.length):new Buffer(e.length),e.copy(f),f;v(e,Error)?f=Object.create(e):void 0===y?(t=Object.getPrototypeOf(e),f=Object.create(t)):(f=Object.create(y),t=y)}if(b){var r=j.indexOf(e);if(-1!=r)return O[r];j.push(e),O.push(f)}for(var n in v(e,m)&&e.forEach(function(e,t){var r=o(t,c-1),n=o(e,c-1);f.set(r,n)}),v(e,_)&&e.forEach(function(e){var t=o(e,c-1);f.add(t)}),e){var u;t&&(u=Object.getOwnPropertyDescriptor(t,n)),u&&null==u.set||(f[n]=o(e[n],c-1))}if(Object.getOwnPropertySymbols){var i=Object.getOwnPropertySymbols(e);for(n=0;n<i.length;n++){var a=i[n];(!(p=Object.getOwnPropertyDescriptor(e,a))||p.enumerable||g)&&(f[a]=o(e[a],c-1),p.enumerable||Object.defineProperty(f,a,{enumerable:!1}))}}if(g){var l=Object.getOwnPropertyNames(e);for(n=0;n<l.length;n++){var p,s=l[n];(p=Object.getOwnPropertyDescriptor(e,s))&&p.enumerable||(f[s]=o(e[s],c-1),Object.defineProperty(f,s,{enumerable:!1}))}}return f}(e,t)}function t(e){return Object.prototype.toString.call(e)}function x(e){var t="";return e.global&&(t+="g"),e.ignoreCase&&(t+="i"),e.multiline&&(t+="m"),t}return w.clonePrototype=function(e){if(null===e)return null;var t=function(){};return t.prototype=e,new t},w.__objToStr=t,w.__isDate=function(e){return"object"==typeof e&&"[object Date]"===t(e)},w.__isArray=function(e){return"object"==typeof e&&"[object Array]"===t(e)},w.__isRegExp=function(e){return"object"==typeof e&&"[object RegExp]"===t(e)},w.__getRegExpFlags=x,w}();
-
 const getPrimitivesOnlyObject = () => {
     return {
         string: 'string',
@@ -61,15 +58,18 @@ const runJob = async (type, numIterations, numPrototypes, config) => {
     const [
         cloneDeepModule,
         lodashModule,
+        cloneModule,
         esToolkitModule
     ] = await Promise.all([
         import('../index.js'),
         import('https://cdn.jsdelivr.net/npm/lodash@4.17.21/+esm'),
+        import('https://esm.run/clone@2.1.2'),
         import('https://esm.sh/es-toolkit@%5E1')
     ]);
 
     const { default: cloneDeep, cloneDeepFully } = cloneDeepModule;
     const lodash = lodashModule.default.cloneDeep;
+    const { default: clone } = cloneModule;
     const esToolkit = esToolkitModule.cloneDeep;
 
     const useStructuredClone = (object) => {

--- a/benchmark/run-job.js
+++ b/benchmark/run-job.js
@@ -1,0 +1,170 @@
+// eslint-disable-next-line
+const clone = function(){function v(e,t){return null!=t&&e instanceof t}var m,_,h;try{m=Map}catch(e){m=function(){}}try{_=Set}catch(e){_=function(){}}try{h=Promise}catch(e){h=function(){}}function w(e,b,t,y,g){"object"==typeof b&&(t=b.depth,y=b.prototype,g=b.includeNonEnumerable,b=b.circular);var j=[],O=[],d="undefined"!=typeof Buffer;return void 0===b&&(b=!0),void 0===t&&(t=1/0),function o(e,c){if(null===e)return null;if(0===c)return e;var f,t;if("object"!=typeof e)return e;if(v(e,m))f=new m;else if(v(e,_))f=new _;else if(v(e,h))f=new h(function(t,r){e.then(function(e){t(o(e,c-1))},function(e){r(o(e,c-1))})});else if(w.__isArray(e))f=[];else if(w.__isRegExp(e))f=new RegExp(e.source,x(e)),e.lastIndex&&(f.lastIndex=e.lastIndex);else if(w.__isDate(e))f=new Date(e.getTime());else{if(d&&Buffer.isBuffer(e))return f=Buffer.allocUnsafe?Buffer.allocUnsafe(e.length):new Buffer(e.length),e.copy(f),f;v(e,Error)?f=Object.create(e):void 0===y?(t=Object.getPrototypeOf(e),f=Object.create(t)):(f=Object.create(y),t=y)}if(b){var r=j.indexOf(e);if(-1!=r)return O[r];j.push(e),O.push(f)}for(var n in v(e,m)&&e.forEach(function(e,t){var r=o(t,c-1),n=o(e,c-1);f.set(r,n)}),v(e,_)&&e.forEach(function(e){var t=o(e,c-1);f.add(t)}),e){var u;t&&(u=Object.getOwnPropertyDescriptor(t,n)),u&&null==u.set||(f[n]=o(e[n],c-1))}if(Object.getOwnPropertySymbols){var i=Object.getOwnPropertySymbols(e);for(n=0;n<i.length;n++){var a=i[n];(!(p=Object.getOwnPropertyDescriptor(e,a))||p.enumerable||g)&&(f[a]=o(e[a],c-1),p.enumerable||Object.defineProperty(f,a,{enumerable:!1}))}}if(g){var l=Object.getOwnPropertyNames(e);for(n=0;n<l.length;n++){var p,s=l[n];(p=Object.getOwnPropertyDescriptor(e,s))&&p.enumerable||(f[s]=o(e[s],c-1),Object.defineProperty(f,s,{enumerable:!1}))}}return f}(e,t)}function t(e){return Object.prototype.toString.call(e)}function x(e){var t="";return e.global&&(t+="g"),e.ignoreCase&&(t+="i"),e.multiline&&(t+="m"),t}return w.clonePrototype=function(e){if(null===e)return null;var t=function(){};return t.prototype=e,new t},w.__objToStr=t,w.__isDate=function(e){return"object"==typeof e&&"[object Date]"===t(e)},w.__isArray=function(e){return"object"==typeof e&&"[object Array]"===t(e)},w.__isRegExp=function(e){return"object"==typeof e&&"[object RegExp]"===t(e)},w.__getRegExpFlags=x,w}();
+
+const getPrimitivesOnlyObject = () => {
+    return {
+        string: 'string',
+        number: 123456789,
+        boolean: true,
+        array: ['string', 123456789, false]
+    };
+};
+
+const getOrdinaryObject = () => {
+    const map = new Map();
+    map.set('p', { p: 'p', g: { h: 'h' }});
+    map.prop = 'property on map';
+    map.set('test', 3);
+
+    const error = new Error('error');
+    const number = 3;
+    Object.freeze(number);
+
+    const object = {
+        f: 'string',
+        map,
+        error,
+        uint: new Uint8Array(new ArrayBuffer(8), 1, 4),
+        date: new Date(Date.now()),
+        frozen: Object.freeze({ test: 3 }),
+        sealed: Object.seal({ test: 3 }),
+        number,
+        bigint: BigInt(1)
+
+    };
+
+    map.set('g', object);
+    object.circular = object;
+
+    return object;
+};
+
+const getNestedObject = () => {
+    const obj = {};
+    let next = obj;
+    for (let number = 0; number < 500; number++) {
+        next.property = {};
+        next = next.property;
+    }
+    return obj;
+};
+
+const getPrototypeChain = (numIterations) => {
+    let temp = {};
+    for (let i = 0; i < numIterations; i++) {
+        temp = Object.create(temp);
+    }
+    return temp;
+};
+
+const runJob = async (type, numIterations, numPrototypes, config) => {
+    const [
+        cloneDeepModule,
+        lodashModule,
+        esToolkitModule
+    ] = await Promise.all([
+        import('../index.js'),
+        import('https://cdn.jsdelivr.net/npm/lodash@4.17.21/+esm'),
+        import('https://esm.sh/es-toolkit@%5E1')
+    ]);
+
+    const { default: cloneDeep, cloneDeepFully } = cloneDeepModule;
+    const lodash = lodashModule.default.cloneDeep;
+    const esToolkit = esToolkitModule.cloneDeep;
+
+    const useStructuredClone = (object) => {
+        return structuredClone(object);
+    };
+
+    const useLodash = (object) => {
+        return lodash(object);
+    };
+
+    const useClone = (object) => {
+        return clone(object, {
+            circular: true,
+            includeNonEnumerable: true
+        });
+    };
+
+    const useEsToolkit = (object) => {
+        return esToolkit(object);
+    };
+
+    const useCloneDeep = (object) => {
+        return cloneDeep(object, {
+            performanceConfig: config,
+            logMode: 'silent'
+        });
+    };
+
+    const useCloneDeepFully = (object) => {
+        return cloneDeepFully(object, { logMode: 'silent' });
+    };
+
+    let object;
+
+    switch (type) {
+    case 'primitives':
+        object = getPrimitivesOnlyObject();
+        break;
+    case 'ordinary':
+        object = getOrdinaryObject();
+        break;
+    case 'nested':
+        object = getNestedObject();
+        break;
+    case 'prototype':
+        object = getPrototypeChain(numPrototypes);
+        break;
+    default:
+        object = undefined;
+        break;
+    }
+
+    const result = [];
+
+    if (object !== undefined) {
+        const funcs = type !== 'prototype'
+            ? [
+                useStructuredClone,
+                useLodash,
+                useClone,
+                useEsToolkit,
+                useCloneDeep
+            ] : [
+                useCloneDeepFully
+            ];
+        console.log(funcs);
+        funcs.forEach((func) => {
+            const max = type === 'prototype'
+                ? 1
+                : numIterations;
+            const divisor = type === 'prototype'
+                ? numPrototypes
+                : numIterations;
+
+            if (func === useCloneDeep || func === useCloneDeepFully) {
+                console.profile();
+            }
+
+            const before = Date.now();
+
+            for (let n = 0; n < max; n++) {
+                func(object);
+            }
+
+            const after = Date.now();
+
+            if (func === useCloneDeep || func === useCloneDeepFully) {
+                console.profileEnd();
+            }
+
+            result.push((after - before) / divisor);
+        });
+    }
+
+    return result;
+};
+
+export default runJob;

--- a/benchmark/worker.js
+++ b/benchmark/worker.js
@@ -1,100 +1,12 @@
-// This script functions as a Web Worker for benchmark.js.
-
-const getPrimitivesOnlyObject = () => {
-    return {
-        string: 'string',
-        number: 123456789,
-        boolean: true,
-        array: ['string', 123456789, false]
-    };
-};
-
-const getOrdinaryObject = () => {
-    const map = new Map();
-    map.set('p', { p_: 'p', g_: { h_: 'h' }});
-    map.prop = 'property on map';
-    map.set('test', 3);
-
-    const error = new Error('error');
-    const number = 3;
-    Object.freeze(number);
-
-    const object = {
-        f_: 'string',
-        map,
-        error,
-        uint: new Uint8Array(new ArrayBuffer(8), 1, 4),
-        date: new Date(Date.now()),
-        frozen: Object.freeze({ test: 3 }),
-        sealed: Object.seal({ test: 3 }),
-        number,
-        bigint: BigInt(1)
-
-    };
-
-    map.set('g', object);
-    object.circular = object;
-
-    return object;
-};
-
-const getNestedObject = () => {
-    const obj = {};
-    let next = obj;
-    for (let number = 0; number < 1000; number++) {
-        next.property = {};
-        next = next.property;
-    }
-    return obj;
-};
+// This script is used as a Web Worker for benchmark.js.
 
 (async () => {
-    const module = await import('../src/clone-deep/clone-deep.js');
-    const cloneDeep = module['default'];
+    const { default: runJob } = await import('./run-job.js');
 
-    const useCloneDeep = (object) => {
-        return cloneDeep(object, { logMode: 'silent' });
-    };
+    onmessage = async ({ data }) => {
+        const { type, numIterations, numPrototypes, config } = data;
 
-    const useStructuredClone = (obj) => {
-        return structuredClone(obj);
-    };
-
-    onmessage = ({ data }) => {
-        const { type, numIterations } = data;
-        let object;
-
-        switch (type) {
-        case 'primitives':
-            object = getPrimitivesOnlyObject();
-            break;
-        case 'ordinary':
-            object = getOrdinaryObject();
-            break;
-        case 'nested':
-            object = getNestedObject();
-            break;
-        default:
-            object = undefined;
-            break;
-        }
-
-        const result = [];
-
-        if (object !== undefined) {
-            [useStructuredClone, useCloneDeep].forEach((func) => {
-                const before = Date.now();
-
-                console.profile();
-                for (let number = 0; number < numIterations; number++) {
-                    func(object);
-                }
-                console.profileEnd();
-
-                const after = Date.now();
-                result.push((after - before) / numIterations);
-            });
-        }
+        const result = await runJob(type, numIterations, numPrototypes, config);
 
         postMessage({ result });
     };

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -46,7 +46,6 @@ export default [{
             ignorePattern: '[\\w\\W]*\\s*@[\\w\\W]*\\s*\\{'
         }],
         '@s/new-parens': ['error', 'always'],
-        '@s/no-extra-parens': 'error',
         '@s/no-floating-decimal': 'error',
         '@s/no-mixed-operators': 'error',
         '@s/no-mixed-spaces-and-tabs': 'error',

--- a/src/clone-deep-fully/clone-deep-fully-internal.js
+++ b/src/clone-deep-fully/clone-deep-fully-internal.js
@@ -128,7 +128,6 @@ export const cloneDeepFullyInternalAsync = async ({
     letCustomizerThrow,
     force
 }) => {
-    // eslint-disable-next-line @s/no-extra-parens
     const { clone } = await /** @type {Promise<{ clone: U }>} */ (
         cloneDeepAsync(value, {
             customizer,

--- a/src/clone-deep-fully/clone-deep-fully.js
+++ b/src/clone-deep-fully/clone-deep-fully.js
@@ -112,7 +112,6 @@ const cloneDeepFully = (value, options) => {
 
     options.async = false;
 
-    /* eslint-disable-next-line @s/no-extra-parens */
     return /** @type {U} */ (cloneDeepFullyProxy(value, options));
 };
 

--- a/src/clone-deep/clone-deep-utils/global-state.js
+++ b/src/clone-deep/clone-deep-utils/global-state.js
@@ -1,5 +1,8 @@
 import { TOP_LEVEL } from './assign.js';
-import { getSupportedPrototypes } from '../../utils/helpers.js';
+import {
+    getSupportedConstructors,
+    getSupportedPrototypes
+} from '../../utils/helpers.js';
 
 /**
  * Container for various data structures often used in cloneDeep.
@@ -56,6 +59,14 @@ export class GlobalState {
      * @readonly
      */
     supportedPrototypes;
+
+    /**
+     * An object mapping constructor names to the constructor itself, or
+     * `undefined` if the constructor is not available in this runtime.
+     * @type {Readonly<{ [key: string]: (new (...args: any[]) => any) | undefined }>}
+     * @readonly
+     */
+    supportedConstructors;
 
     /**
      * This is used by cloneDeepFully to check if an object with a cloning
@@ -130,6 +141,7 @@ export class GlobalState {
         this.log = log;
         this.queue = [{ value, parentOrAssigner: TOP_LEVEL }];
         this.supportedPrototypes = getSupportedPrototypes();
+        this.supportedConstructors = getSupportedConstructors();
         this.parentObjectRegistry = parentObjectRegistry;
         this.prioritizePerformance = Boolean(prioritizePerformance);
         this.ignoreCloningMethods = Boolean(ignoreCloningMethods);

--- a/src/clone-deep/clone-deep-utils/handle-cloning-method.js
+++ b/src/clone-deep/clone-deep-utils/handle-cloning-method.js
@@ -5,7 +5,7 @@ import {
     isObject,
     isPropertyKeyArray
 } from '../../utils/type-checking.js';
-import { handleCustomError } from './misc.js';
+import { checkParentObjectRegistry, handleCustomError } from './misc.js';
 
 /** @typedef {import('../../utils/types').Assigner} Assigner */
 
@@ -35,7 +35,13 @@ export const handleCloningMethods = ({
     saveClone
 }) => {
 
-    const { log, pendingResults, async: asyncMode, doThrow } = globalState;
+    const {
+        log,
+        pendingResults,
+        parentObjectRegistry,
+        async: asyncMode,
+        doThrow
+    } = globalState;
 
     const { value } = queueItem;
 
@@ -58,6 +64,16 @@ export const handleCloningMethods = ({
 
     try {
         if (!isCallable(value[CLONE])) {
+            return {
+                cloned,
+                ignoreProps,
+                ignoreProto,
+                useCloningMethod: false,
+                async
+            };
+        }
+
+        if (checkParentObjectRegistry(value, parentObjectRegistry)) {
             return {
                 cloned,
                 ignoreProps,

--- a/src/clone-deep/clone-deep-utils/handle-ecma-types.js
+++ b/src/clone-deep/clone-deep-utils/handle-ecma-types.js
@@ -8,13 +8,13 @@ import {
 import { getPrototype } from '../../utils/metadata.js';
 import { isIterable, isTypedArray } from '../../utils/type-checking.js';
 
-/** @typedef {import('../../utils/types.js').Assigner} Assigner */
+/** @typedef {import('../../utils/types').Assigner} Assigner */
 
 /**
  * @param {Object} spec
  * @param {import('./global-state.js').GlobalState} spec.globalState
  * The fundamental data structures used for cloneDeep.
- * @param {import('../../types.js').QueueItem} spec.queueItem
+ * @param {import('../../types').QueueItem} spec.queueItem
  * Describes the value and metadata of the data being cloned.
  * @param {string} spec.tag
  * The tag of the provided value.
@@ -149,7 +149,7 @@ export const handleEcmaTypes = ({
                 : new AggregateError(errors, message, { cause });
 
         } else {
-            /** @type {import('../../utils/types.js').AtomicErrorConstructor} */
+            /** @type {import('../../utils/types').AtomicErrorConstructor} */
             const ErrorConstructor = getAtomicErrorConstructor(error, log);
 
             const { cause } = error;
@@ -193,7 +193,7 @@ export const handleEcmaTypes = ({
     } else if (isTypedArray(value, prioritizePerformance, tag)
             || Tag.DATAVIEW === tag) {
 
-        /** @type {import('../../utils/types.js').TypedArrayConstructor} */
+        /** @type {import('../../utils/types').TypedArrayConstructor} */
         const TypedArray = getTypedArrayConstructor(tag, log);
 
         // copy data over to clone

--- a/src/clone-deep/clone-deep-utils/handle-ecma-types.js
+++ b/src/clone-deep/clone-deep-utils/handle-ecma-types.js
@@ -8,13 +8,13 @@ import {
 import { getPrototype } from '../../utils/metadata.js';
 import { isIterable, isTypedArray } from '../../utils/type-checking.js';
 
-/** @typedef {import('../../utils/types').Assigner} Assigner */
+/** @typedef {import('../../utils/types.js').Assigner} Assigner */
 
 /**
  * @param {Object} spec
  * @param {import('./global-state.js').GlobalState} spec.globalState
  * The fundamental data structures used for cloneDeep.
- * @param {import('../../types').QueueItem} spec.queueItem
+ * @param {import('../../types.js').QueueItem} spec.queueItem
  * Describes the value and metadata of the data being cloned.
  * @param {string} spec.tag
  * The tag of the provided value.
@@ -29,7 +29,7 @@ import { isIterable, isTypedArray } from '../../utils/type-checking.js';
  *     nativeTypeDetected: boolean
  * }}
  */
-export const handleNativeTypes = ({
+export const handleEcmaTypes = ({
     globalState,
     queueItem,
     tag,
@@ -149,7 +149,7 @@ export const handleNativeTypes = ({
                 : new AggregateError(errors, message, { cause });
 
         } else {
-            /** @type {import('../../utils/types').AtomicErrorConstructor} */
+            /** @type {import('../../utils/types.js').AtomicErrorConstructor} */
             const ErrorConstructor = getAtomicErrorConstructor(error, log);
 
             const { cause } = error;
@@ -193,7 +193,7 @@ export const handleNativeTypes = ({
     } else if (isTypedArray(value, prioritizePerformance, tag)
             || Tag.DATAVIEW === tag) {
 
-        /** @type {import('../../utils/types').TypedArrayConstructor} */
+        /** @type {import('../../utils/types.js').TypedArrayConstructor} */
         const TypedArray = getTypedArrayConstructor(tag, log);
 
         // copy data over to clone

--- a/src/clone-deep/clone-deep-utils/handle-tag.js
+++ b/src/clone-deep/clone-deep-utils/handle-tag.js
@@ -1,5 +1,5 @@
 import { handleError } from './misc.js';
-import { handleNativeTypes } from './handle-native-types.js';
+import { handleEcmaTypes } from './handle-ecma-types.js';
 import { handleSyncWebTypes } from './handle-sync-web-types.js';
 import { Warning } from '../../utils/clone-deep-warning.js';
 import { handleAsyncWebTypes } from './handle-async-web-types.js';
@@ -57,7 +57,7 @@ export const handleTag = ({
             ignoreProps,
             ignoreProto,
             nativeTypeDetected
-        } = handleNativeTypes({
+        } = handleEcmaTypes({
             globalState,
             queueItem,
             tag,
@@ -78,19 +78,18 @@ export const handleTag = ({
             }));
         }
 
-        /**
-         * Pushes the given promise into the list of pending results.
-         * @param {Promise<any>} promise
-         */
-        const pushPendingResult = (promise) => {
-            pendingResults?.push({
-                queueItem,
-                promise,
-                propsToIgnore
-            });
-        };
-
         if (async && !nativeTypeDetected && !webTypeDetected) {
+            /**
+             * Pushes the given promise into the list of pending results.
+             * @param {Promise<any>} promise
+             */
+            const pushPendingResult = (promise) => {
+                pendingResults?.push({
+                    queueItem,
+                    promise,
+                    propsToIgnore
+                });
+            };
             asyncWebTypeDetected = handleAsyncWebTypes({
                 queueItem,
                 tag,

--- a/src/clone-deep/clone-deep-utils/process-queue.js
+++ b/src/clone-deep/clone-deep-utils/process-queue.js
@@ -1,9 +1,5 @@
 import { assign } from './assign.js';
-import {
-    checkCloneStore,
-    checkParentObjectRegistry,
-    finalizeClone
-} from './misc.js';
+import { checkCloneStore, finalizeClone } from './misc.js';
 import { handleCustomizer } from './handle-customizer.js';
 import { handleTag } from './handle-tag.js';
 import { handleCloningMethods } from './handle-cloning-method.js';
@@ -22,7 +18,6 @@ export const processQueue = (globalState) => {
         customizer,
         cloneStore,
         isExtensibleSealFrozen,
-        parentObjectRegistry,
         prioritizePerformance,
         ignoreCloningMethods
     } = globalState;
@@ -91,11 +86,8 @@ export const processQueue = (globalState) => {
          */
         const propsToIgnore = [];
 
-        /** Whether the cloning methods should be observed this loop. */
-        let ignoreCloningMethodsThisLoop = false;
-
         /** Identifies the type of the value. */
-        const tag = getTag(value, prioritizePerformance);
+        const tag = getTag(value, prioritizePerformance, globalState);
 
         cloneIsCached = checkCloneStore(value, cloneStore, saveClone);
 
@@ -121,10 +113,7 @@ export const processQueue = (globalState) => {
 
         const ignore = cloneIsCached || useCustomizerClone || isPrimitive;
 
-        ignoreCloningMethodsThisLoop = checkParentObjectRegistry(
-            value, parentObjectRegistry);
-
-        if (!ignore && !ignoreCloningMethods && !ignoreCloningMethodsThisLoop) {
+        if (!ignore && !ignoreCloningMethods) {
             const cloningMethodResult = handleCloningMethods({
                 globalState,
                 queueItem,

--- a/src/clone-deep/clone-deep.js
+++ b/src/clone-deep/clone-deep.js
@@ -127,7 +127,6 @@ const cloneDeep = (value, options) => {
 
     options.async = false;
 
-    /* eslint-disable-next-line @s/no-extra-parens */
     return /** @type {U} */ (cloneDeepProxy(value, options));
 };
 
@@ -154,7 +153,6 @@ export const cloneDeepAsync = (value, options) => {
 
     options.async = true;
 
-    /* eslint-disable-next-line @s/no-extra-parens */
     return /** @type {Promise<{ clone: U }>} */(cloneDeepProxy(value, options));
 };
 

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -133,13 +133,15 @@ const __global = globalThis;
 /** @type {{ [key: string]: new (...args: any[]) => any | undefined }} */
 const global = __global;
 
+/** @typedef {new (...args: any[]) => any} Constructor */
+
 /**
  * Attempts to retreive a web API from the global object.
  * Doing this in a way that utilizes TypeScript effectively is obtuse, hence
  * this function was made so that TypeScript jank doesn't obfuscate code
  * elsewhere.
  * @param {string} string
- * @returns {new (...args: any[]) => any | undefined}
+ * @returns {Constructor | undefined}
  */
 export const getConstructorFromString = (string) => {
     return global[string];
@@ -170,6 +172,23 @@ export const getSupportedPrototypes = () => {
     });
 
     return supportedPrototypes.concat(webApiPrototypes);
+};
+
+/**
+ * Returns an object containing all constructors in this runtime.
+ * The object maps names of a constructor ('Array', 'Map', 'AudioData') to the
+ * constructor itself, or `undefined` if the constructor is not available in
+ * this runtime.
+ * @returns {Readonly<{ [key: string]: Constructor | undefined }>}
+ */
+export const getSupportedConstructors = () => {
+    /** @type {{ [key: string]: Constructor | undefined }} */
+    const result = {};
+    Object.keys(Tag).forEach((tag) => {
+        const name = tag.substring(8, tag.length - 1);
+        result[name] = getConstructorFromString(name);
+    });
+    return Object.freeze(result);
 };
 
 /**

--- a/src/utils/type-checking.js
+++ b/src/utils/type-checking.js
@@ -73,7 +73,7 @@ export const getGeometryCheckers = (webApiString, methodOrProp, property) => {
      */
     const isSubclass = (value) => {
         const PotentialWebApi = getConstructorFromString(webApiString);
-        if (!isCallable(PotentialWebApi)) {
+        if (typeof PotentialWebApi !== 'function') {
             return false;
         }
 
@@ -93,7 +93,7 @@ export const getGeometryCheckers = (webApiString, methodOrProp, property) => {
             if (typeof methodOrProp === 'object') {
                 descriptors[methodOrProp.name].get?.call(value);
             } else {
-                PotentialWebApi.prototype[methodOrProp].call(value);
+                PotentialWebApi?.prototype[methodOrProp].call(value);
             }
             result = true;
         } catch {
@@ -196,6 +196,24 @@ export const isImageData = (value) => {
             return false;
         }
         getDescriptors(ImageData.prototype).width.get?.call(imageData);
+        return true;
+    } catch {
+        return false;
+    }
+};
+
+/**
+ * Returns `true` if the given value is a DOMException, `false` otherwise.
+ * @param {any} value
+ * @returns {boolean}
+ */
+export const isDOMException = (value) => {
+    try {
+        const domException = castAsInstanceOf(value, DOMException);
+        if (!domException) {
+            return false;
+        }
+        getDescriptors(DOMException.prototype).code.get?.call(domException);
         return true;
     } catch {
         return false;

--- a/test/test.js
+++ b/test/test.js
@@ -15,7 +15,6 @@ import cloneDeep, {
 } from '../index.js';
 
 import { CLONE, Tag } from '../src/utils/constants.js';
-import { getTag } from '../src/clone-deep/clone-deep-utils/get-tag.js';
 import {
     castAsInstanceOf,
     createFileList,
@@ -45,7 +44,7 @@ const getProto = (object) => {
     return Object.getPrototypeOf(object);
 };
 const tagOf = (value) => {
-    return getTag(value);
+    return Object.prototype.toString.call(value);
 };
 
 assert.true = (condition) => {
@@ -1150,7 +1149,7 @@ try {
             const clone = cloneDeep(fakeFile);
 
             // -- assert
-            assert.strictEqual(Tag.OBJECT, getTag(clone));
+            assert.strictEqual(Tag.OBJECT, tagOf(clone));
         });
 
         describe('geometry web APIs', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,11 +5,12 @@
             "ES2022", 
             "DOM"
         ],
-        "target": "ES2022",
+        "target": "ES5",
         "allowJs": true,
         "checkJs": true,
         "strict": true,
-        "noEmit": true
+        "noEmit": false,
+        "downlevelIteration": true
     },
     "include": [
         "src/**/*"


### PR DESCRIPTION
- added timers for lodash's, es-toolkit's, and clone's performance
- add checkboxes to run in various performance modifiers dynamically
- add secondary box to benchmark cloneDeepFully
- create an input field to determine the number of (method-less) prototypes to clone
- added the option to run the benchmark in the main thread so that browser development tools can analyze the source code better